### PR TITLE
Call error callback if jsonp load script fails.

### DIFF
--- a/dist/feedhenry-latest.js
+++ b/dist/feedhenry-latest.js
@@ -4891,6 +4891,11 @@ RSAKey.prototype.encrypt = RSAEncrypt;
     script.async = "async";
     script.src = url;
     script.type = "text/javascript";
+    script.onerror = function () {
+      if (callback && typeof callback === "function") {
+        callback("network");
+      }
+    };
     script.onload = script.onreadystatechange = function () {
       if (!script.readyState || /loaded|complete/.test(script.readyState)) {
         script.onload = script.onreadystatechange = null;
@@ -5057,7 +5062,11 @@ RSAKey.prototype.encrypt = RSAEncrypt;
             url += "&_jsonpdata=" + encodeURIComponent(JSON.stringify(o.data));
           }
         }
-        __load_script(url);
+        __load_script(url, function(error){
+          if(error) {
+            done(0, 'network');
+          }
+        });
       }
     };
 

--- a/src/feedhenry.js
+++ b/src/feedhenry.js
@@ -227,6 +227,11 @@
     script.async = "async";
     script.src = url;
     script.type = "text/javascript";
+    script.onerror = function () {
+      if (callback && typeof callback === "function") {
+        callback("network");
+      }
+    };
     script.onload = script.onreadystatechange = function () {
       if (!script.readyState || /loaded|complete/.test(script.readyState)) {
         script.onload = script.onreadystatechange = null;
@@ -393,7 +398,11 @@
             url += "&_jsonpdata=" + encodeURIComponent(JSON.stringify(o.data));
           }
         }
-        __load_script(url);
+        __load_script(url, function(error){
+          if(error) {
+            done(0, 'network');
+          }
+        });
       }
     };
 


### PR DESCRIPTION
Fix for act calls never calling error callback when load script fails due to lack of network.