### PR TITLE
6512 - Modify fh-js-sdk to take url as a query param (instead of local c...

### DIFF
--- a/src/modules/appProps.js
+++ b/src/modules/appProps.js
@@ -8,9 +8,21 @@ var app_props = null;
 var load = function(cb) {
   var doc_url = document.location.href;
   var url_params = qs(doc_url);
-  var local = (typeof url_params.fhconfig !== 'undefined');
-  var config_url = url_params.fhconfig || consts.config_js;
+  var local = (typeof url_params.url !== 'undefined');
 
+  // For local environments, no init needed
+  if (local) {
+    app_props = {};
+    app_props.local = true;
+    app_props.host = url_params.url;
+    app_props.appid = "000000000000000000000000";
+    app_props.appkey = "0000000000000000000000000000000000000000";
+    app_props.projectid = "000000000000000000000000";
+    app_props.connectiontag = "0.0.1";
+    return cb(null, app_props);
+  }
+
+  var config_url = url_params.fhconfig || consts.config_js;
   ajax({
     url: config_url,
     dataType: "json",
@@ -21,16 +33,6 @@ var load = function(cb) {
         return cb(new Error("app_config_missing"));
       } else {
         app_props = data;
-
-        // For local environments, no init needed
-        if (local) {
-          // Set defaults for keys other than host
-          app_props.local = true;
-          app_props.appid = "000000000000000000000000";
-          app_props.appkey = "0000000000000000000000000000000000000000";
-          app_props.projectid = "000000000000000000000000";
-          app_props.connectiontag = "0.0.1";
-        }
 
         cb(null, app_props);
       }


### PR DESCRIPTION
...onfig file):

No need for developers to create a local version of fhconfig.json, just pass ?url= now instead. This can now be used directly from grunt, e.g. http://localhost:9001/?url=http://localhost:8001
