### PR TITLE
Fhmobsdk 53 local fh params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
 
+##2.5.2 - 2015-03-26 - Wei Li
+* FHMOBSDK-56 - Fix an issue with the sync framework.
+
 ## 2.5.1 - 2014-12-01 - IR242 - Martin Murphy
 * 8319 - fix location button label in apppforms app
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.5.1-BUILD-NUMBER",
+  "version": "2.5.2-BUILD-NUMBER",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/modules/appProps.js
+++ b/src/modules/appProps.js
@@ -8,10 +8,15 @@ var app_props = null;
 
 var load = function(cb) {
   var doc_url = document.location.href;
-  var url_params = qs(doc_url);
+  var url_params = qs(doc_url.replace(/#.*?$/g, ''));
+  var url_props = {};
+  
+  //only use fh_ prefixed params
   for(var key in url_params){
-    if(url_params.hasOwnProperty(key)){
-      url_params[key] = url_params[key].replace(/#.*?$/g, '');
+    if(url_params.hasOwnProperty(key) ){
+      if(key.indexOf('fh_') === 0){
+        url_props[key.substr(3)] = url_params[key]; 
+      }
     }
   }
   
@@ -24,12 +29,13 @@ var load = function(cb) {
   };
   
   function setProps(props){
-    _.extend(app_props, url_params, props);
+    _.extend(app_props, props, url_props);
+    
     if(typeof url_params.url !== 'undefined'){
      app_props.host = url_params.url; 
     }
     
-    app_props.local = !!(url_params.host || url_params.url);
+    app_props.local = !!(url_props.host || url_params.url);
     cb(null, app_props);
   }
 

--- a/src/modules/appProps.js
+++ b/src/modules/appProps.js
@@ -2,25 +2,31 @@ var consts = require("./constants");
 var ajax = require("./ajax");
 var logger = require("./logger");
 var qs = require("./queryMap");
+var _ = require('underscore');
 
 var app_props = null;
 
 var load = function(cb) {
   var doc_url = document.location.href;
   var url_params = qs(doc_url);
-  var local = (typeof url_params.url !== 'undefined');
-
-  // For local environments, no init needed
-  if (local) {
-    app_props = {};
-    app_props.local = true;
-    app_props.host = url_params.url.replace(/#.*?$/g, '');
-    app_props.appid = "000000000000000000000000";
-    app_props.appkey = "0000000000000000000000000000000000000000";
-    app_props.projectid = "000000000000000000000000";
-    app_props.connectiontag = "0.0.1";
-    app_props.loglevel = url_params.loglevel;
-    return cb(null, app_props);
+  
+  //default properties
+  app_props = {
+    appid: "000000000000000000000000",
+    appkey: "0000000000000000000000000000000000000000",
+    projectid: "000000000000000000000000",
+    connectiontag: "0.0.1"
+  };
+  
+  function setProps(props){
+    _.extend(app_props, url_params, props);
+    if(typeof url_params.url !== 'undefined'){
+     app_props.host = url_params.url; 
+    }
+    
+    app_props.host = app_props.host.replace(/#.*?$/g, '');
+    app_props.local = !!(url_params.host || url_params.url);
+    cb(null, app_props);
   }
 
   var config_url = url_params.fhconfig || consts.config_js;
@@ -33,21 +39,18 @@ var load = function(cb) {
       if (null == data) {
         //fh v2 only
         if(window.fh_app_props){
-          app_props = window.fh_app_props;
-          return cb(null, window.fh_app_props);
+          return setProps(window.fh_app_props);
         }
         return cb(new Error("app_config_missing"));
       } else {
-        app_props = data;
 
-        cb(null, app_props);
+        setProps(data);
       }
     },
     error: function(req, statusText, error) {
       //fh v2 only
       if(window.fh_app_props){
-        app_props = window.fh_app_props;
-        return cb(null, window.fh_app_props);
+        return setProps(window.fh_app_props);
       }
       logger.error(consts.config_js + " Not Found");
       cb(new Error("app_config_missing"));

--- a/src/modules/appProps.js
+++ b/src/modules/appProps.js
@@ -9,6 +9,11 @@ var app_props = null;
 var load = function(cb) {
   var doc_url = document.location.href;
   var url_params = qs(doc_url);
+  for(var key in url_params){
+    if(url_params.hasOwnProperty(key)){
+      url_params[key] = url_params[key].replace(/#.*?$/g, '');
+    }
+  }
   
   //default properties
   app_props = {
@@ -24,7 +29,6 @@ var load = function(cb) {
      app_props.host = url_params.url; 
     }
     
-    app_props.host = app_props.host.replace(/#.*?$/g, '');
     app_props.local = !!(url_params.host || url_params.url);
     cb(null, app_props);
   }

--- a/src/modules/handleError.js
+++ b/src/modules/handleError.js
@@ -7,7 +7,7 @@ module.exports = function(fail, req, resStatus, error){
     try{
       statusCode = req.status;
       var res = JSON.parse(req.responseText);
-      errraw = res.error || res.msg;
+      errraw = res.error || res.msg || res;
       if (errraw instanceof Array) {
         errraw = errraw.join('\n');
       }


### PR DESCRIPTION
This change does two things. First it always attempts to load fhconfig.json regardless if it is local (defined as having a query parameter "url" set). Second it allows any of the fh-params to be overridden from a query parameter. I added the second part because I think it answers the first attempt at allowing a host override more generically. We might consider prefixing them with "fh-". It seems somewhat obtuse to just have a parameter of "url" which may collide with someone's app code.

This change fixes issue https://issues.jboss.org/browse/FHMOBSDK-53