### PR TITLE
Indexeddb windows 8.1 support (IE 11)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,7 @@ module.exports = function(grunt) {
           "libs/lawnchair/lawnchairWindowNameStorageAdapter.js",
           "libs/lawnchair/lawnchairLocalStorageAdapter.js",
           "libs/lawnchair/lawnchairWebkitSqlAdapter.js",
+          "libs/lawnchair/lawnchairIndexDbAdapter.js",
           "libs/lawnchair/lawnchairHtml5FileSystem.js",
           "libs/lawnchair/lawnchairMemoryAdapter.js"
         ],

--- a/libs/lawnchair/lawnchairIndexDbAdapter.js
+++ b/libs/lawnchair/lawnchairIndexDbAdapter.js
@@ -17,7 +17,7 @@ Lawnchair.adapter('indexed-db', (function(){
     init:function(options, callback) {
       this.idb = getIDB();
       this.waiting = [];
-      var request = this.idb.open(this.name, "2.0");
+      var request = this.idb.open(this.name, 2);
       var self = this;
       var cb = self.fn(self.name, callback);
       var win = function(){ return cb.call(self, self); }
@@ -116,7 +116,7 @@ Lawnchair.adapter('indexed-db', (function(){
 
 
     get:function(key, callback) {
-      if(!this.store) {
+      if(!this.store || !this.db) {
         this.waiting.push(function() {
           this.get(key, callback);
         });


### PR DESCRIPTION
include the indexed-db adapter in the grunt build and minor updates to the lawnchair adapter.