### PR TITLE
Added A Global Event Listener For Appforms APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.9.0 - 2015-10-06 - Niall Donnelly 
 
 * FH-2330 - Added A Global Event Listener For Appforms Models
+* FH-2340 - Populating the _id parameter for uploaded submissions
 
 ## 2.8.0 - 2015-10-02 - Niall Donnelly/Wei Li/Shannon Poole
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.9.0 - 2015-10-06 - Niall Donnelly 
+
+* FH-2330 - Added A Global Event Listener For Appforms Models
+
 ## 2.8.0 - 2015-10-02 - Niall Donnelly/Wei Li/Shannon Poole
 
 * FH-2299 - Added New Submissions Accessor Functions. Added Progress JSON update. - Niall Donnelly

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "homepage": "https://github.com/feedhenry/fh-js-sdk",
   "authors": [
     "npm@feedhenry.com"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/appforms/src/core/020-utils.js
+++ b/src/appforms/src/core/020-utils.js
@@ -5,6 +5,9 @@ appForm.utils = function(module) {
   module.getTime = getTime;
   module.send=send;
   module.isPhoneGap = isPhoneGap;
+  module.generateGlobalEventName = function(type, eventName){
+    return "" + type + ":" + eventName;
+  };
 
   function isPhoneGap() {
     return (typeof window.Phonegap !== "undefined" || typeof window.cordova !== "undefined");

--- a/src/appforms/src/core/040-Model.js
+++ b/src/appforms/src/core/040-Model.js
@@ -30,17 +30,32 @@ appForm.models = function (module) {
     }
   };
 
+  Model.prototype.getType = function(){
+    return this.get('_type');
+  };
+
   Model.prototype.clearEvents = function(){
     this.events = {};
   };
   Model.prototype.emit = function () {
     var args = Array.prototype.slice.call(arguments, 0);
-    var e = args.shift();
-    var funcs = this.events[e];
+    var eventName = args.shift();
+    var funcs = this.events[eventName];
+
+    var globalArgs = args.slice(0);
+
     if (funcs && funcs.length > 0) {
       for (var i = 0; i < funcs.length; i++) {
         var func = funcs[i];
         func.apply(this, args);
+        //Also emitting a global event if the
+        var type = this.getType();
+        if(type){
+          var globalEmitName = this.utils.generateGlobalEventName(type, eventName);
+          globalArgs.unshift(globalEmitName);
+          $fh.forms.emit.apply(this, globalArgs);
+        }
+
       }
     }
   };

--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -963,6 +963,7 @@ appForm.models = function(module) {
   Submission.prototype.setRemoteSubmissionId = function(submissionId){
     if(submissionId){
       this.set("submissionId", submissionId);
+      this.set("_id", submissionId);
     }
   };
   return module;

--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -458,6 +458,9 @@ appForm.models = function(module) {
   Submission.prototype.getStatus = function() {
     return this.get('status');
   };
+  Submission.prototype.getErrorMessage = function(){
+    return this.get('errorMessage', 'No Error');
+  };
   /**
    * check if a target status is valid
    * @param  {[type]}  targetStatus [description]

--- a/src/appforms/src/core/040-Model12UploadTask.js
+++ b/src/appforms/src/core/040-Model12UploadTask.js
@@ -660,7 +660,7 @@ appForm.models = function (module) {
         if(_err){
           return cb(_err);
         }
-        model.set('submissionId', submissionId);
+        model.setRemoteSubmissionId(submissionId);
         model.submitted(cb);
       });
     }

--- a/src/appforms/src/core/050-api.js
+++ b/src/appforms/src/core/050-api.js
@@ -10,6 +10,43 @@ appForm.api = function (module) {
   module.downloadSubmission = downloadSubmission;
   module.init = appForm.init;
   module.log=appForm.models.log;
+  module._events = {};
+
+  //Registering For Global Events
+  module.on = function(name, func, callOnce){
+    if (!module._events[name]) {
+      module._events[name] = [];
+    }
+    if (module._events[name].indexOf(func) < 0) {
+      module._events[name].push({
+        callOnce: callOnce,
+        func: func
+      });
+    }
+  };
+
+  module.once = function(name, func){
+    module.on(name, func, true);
+  };
+
+  //Emitting A Global Event
+  module.emit = function () {
+    var args = Array.prototype.slice.call(arguments, 0);
+    var eventName = args.shift();
+    var funcDetails = module._events[eventName];
+    if (funcDetails && funcDetails.length > 0) {
+      for (var i = 0; i < funcDetails.length; i++) {
+        var functionToCall = funcDetails[i].func;
+        //If the function was not already called, or is not only set to call once, the call the function,
+        //Otherwise, don't call it.
+        if(!funcDetails.called || !funcDetails.callOnce){
+          funcDetails.called = true;
+          functionToCall.apply(this, args);
+        }
+      }
+    }
+  };
+
   var _submissions = null;
   var waitOnSubmission = {};
   var formConfig = appForm.models.config;

--- a/src/appforms/tests/tests/core/040-Model06Submission.js
+++ b/src/appforms/tests/tests/core/040-Model06Submission.js
@@ -324,6 +324,8 @@ describe("Submission model", function() {
                 assert.ok(submissionId);
                 assert.ok(submission.getLocalId());
                 assert.ok(submission.getRemoteSubmissionId());
+                //The _id field should be set
+                assert.equal(submission.getRemoteSubmissionId(), submission.get('_id'));
                 done();
             });
             submission.submit(function(err) {

--- a/src/appforms/tests/tests/core/050-api.js
+++ b/src/appforms/tests/tests/core/050-api.js
@@ -178,4 +178,70 @@ describe("$fh.forms API", function() {
       done();
     });
   });
+  it("$fh.forms.on function should register a global event emitter", function(done){
+    //First Register A Function to be emitted
+    var modelEventCalled = false;
+    var firstArg = "arg1";
+    var secondArg = "arg2";
+
+    var testModel = new appForm.models.Model({
+      _type: "somemodel"
+    });
+
+    testModel.on('someevent', function(arg1, arg2){
+      modelEventCalled = true;
+      assert.equal(firstArg, arg1);
+      assert.equal(secondArg, arg2);
+      assert.strictEqual(this, testModel);
+    });
+
+    //A Global Monitoring Function
+    var functionToEmit = function(arg1, arg2){
+      assert.equal(firstArg, arg1);
+      assert.equal(secondArg, arg2);
+      assert.equal(true, modelEventCalled);
+      assert.strictEqual(this, testModel);
+      done();
+    };
+
+    appForm.api.on("somemodel:someevent", functionToEmit);
+
+    testModel.emit("someevent", firstArg, secondArg);
+  });
+  it("$fh.forms.once function should register a global event emitter to be called only once", function(done){
+    //First Register A Function to be emitted
+    var modelEventCalled = false;
+    var numTimesGlobalEventCalled = 0;
+    var firstArg = "arg1";
+    var secondArg = "arg2";
+
+    var testModel = new appForm.models.Model({
+      _type: "somemodel"
+    });
+
+    testModel.on('onceevent', function(arg1, arg2){
+      modelEventCalled = true;
+      assert.equal(firstArg, arg1);
+      assert.equal(secondArg, arg2);
+      assert.strictEqual(this, testModel);
+    });
+
+    //A Global Monitoring Function
+    var functionToEmitOnce = function(arg1, arg2){
+      numTimesGlobalEventCalled++;
+      assert.equal(1, numTimesGlobalEventCalled);
+      assert.equal(firstArg, arg1);
+      assert.equal(secondArg, arg2);
+      //The third argument should not exist
+      assert.equal(undefined, arguments[2]);
+      assert.equal(true, modelEventCalled);
+      assert.strictEqual(this, testModel);
+      done();
+    };
+
+    appForm.api.once("somemodel:onceevent", functionToEmitOnce);
+
+    testModel.emit("onceevent", firstArg, secondArg);
+    testModel.emit("onceevent", firstArg, secondArg, "someotherarg");
+  });
 });


### PR DESCRIPTION
Added A global event listener for appforms model events.

With this change, a user can call: e.g.

$fh.forms.on("modelType:eventname", function(){})
and
$fh.forms.once("modelType:eventname", function(){})  

to register for all events from different submissions.