### PR TITLE
Added event driven approach to fh.forms.downloadSubmission API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.10.0 - 2015-10-07 - Niall Donnelly 
+
+* FH-2290 - Added Event Driven Approach To $fh.forms.downloadSubmission API.
+
 ## 2.9.0 - 2015-10-06 - Niall Donnelly 
 
 * FH-2330 - Added A Global Event Listener For Appforms Models
-* FH-2340 - Populating the _id parameter for uploaded submissions
+* FH-2340 - Populating the _id parameter for uploaded submissions.
 
 ## 2.8.0 - 2015-10-02 - Niall Donnelly/Wei Li/Shannon Poole
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "homepage": "https://github.com/feedhenry/fh-js-sdk",
   "authors": [
     "npm@feedhenry.com"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/appforms/tests/tests/core/050-api.js
+++ b/src/appforms/tests/tests/core/050-api.js
@@ -150,8 +150,34 @@ describe("$fh.forms API", function() {
       assert.ok(submission);
       console.log("Submission Data: ", submission);
       assert.ok(submission.getRemoteSubmissionId().length > 0);
-      done();
+      submission.clearLocal(function(err){
+        assert.ok(!err, "Expected No Error When Clearing Submission");
+        done(err);
+      });
     });
+  });
+  it("$fh.forms.downloadSubmission No Callback. Global Event Listener Instead", function(done){
+    this.timeout(3000);
+    var submissionId = "submissionData";
+    var downloadSubmission = appForm.api.downloadSubmission;
+    
+    appForm.api.once('submission:error', function(err){
+      assert.ok(!err, "Expected No Error " + err);
+      done(err);
+    });
+    
+    appForm.api.once('submission:downloaded', function(remoteSubmissionId){
+      assert.equal("submissionData", remoteSubmissionId);
+      assert.equal("submissionData", this.getRemoteSubmissionId());
+      //Clearing Out The Submission.
+      this.clearLocal(function(err){
+        assert.ok(!err, "Expected No Error When Clearing Submission");
+        done(err);
+      });
+    });
+
+    //In this case, the submission is queued for download, but does not wait for a download to complete.
+    downloadSubmission({submissionId: submissionId});
   });
   it("$fh.forms.downloadSubmission with files", function(done){
     this.timeout(10000);


### PR DESCRIPTION
This allows users to call the $fh.forms.downloadSubmission API without the callback.

This will queue the submission for download and global events can then be used to subscribe to the submission download events.