### PR TITLE
Fixed Cached File Extension Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.10.1 - 2015-10-14 - Niall Donnelly 
+
+* FH-2290 - Fixed File Extension For Cached Files
+
 ## 2.10.0 - 2015-10-07 - Niall Donnelly 
 
 * FH-2290 - Added Event Driven Approach To $fh.forms.downloadSubmission API.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "homepage": "https://github.com/feedhenry/fh-js-sdk",
   "authors": [
     "npm@feedhenry.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/appforms/src/core/040-Model07FieldFile.js
+++ b/src/appforms/src/core/040-Model07FieldFile.js
@@ -76,9 +76,14 @@ appForm.models.Field = function (module) {
         //Submitting an existing file already saved, no need to save.
         return cb(null, previousFile);
       }
+      //If the value has no extension and there is a previous, then it is the same file -- just the hashed version.
+      if(fileType === "application/octet-stream"){
+        return cb(null, previousFile);
+      }
     }
 
-    var rtnJSON = {
+    //The file to be submitted is new
+    previousFile =  {
       'fileName': fileName,
       'fileSize': file.size,
       'fileType': fileType,
@@ -88,15 +93,13 @@ appForm.models.Field = function (module) {
       'contentType': 'binary'
     };
 
-    //The file to be submitted is new
-    previousFile = rtnJSON;
-
     var name = fileName + new Date().getTime() + Math.ceil(Math.random() * 100000);
     appForm.utils.md5(name, function (err, res) {
       hashName = res;
       if (err) {
         hashName = name;
       }
+
       hashName = 'filePlaceHolder' + hashName;
 
       if(fileName.length === 0){


### PR DESCRIPTION
This fix resolves an issue in the $fh.forms API where file extensions were not being kept when cacheing files.