### PR TITLE
remove override of push function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.12.0 - 2015-11-24 - Erik Jan de Wit
+* RHMAP-2970 - Removed api override
+
 ## 2.11.0 - 2015-10-15 - Wei Li
 * RHMAP-2455 - Fix a few issues with the sync framework
   * Make sure the user changes are not reverted if cloud is slow to response

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/appforms/src/core/000-api-v2.js
+++ b/src/appforms/src/core/000-api-v2.js
@@ -1506,9 +1506,6 @@
     file: function(p, s, f) {
       f('file_nosupport');
     },
-    push: function(p, s, f) {
-      f('push_nosupport');
-    },
     env: function(p, s, f) {
       s({
         height: window.innerHeight,
@@ -1896,10 +1893,6 @@
     handleargs(arguments, {
       act: 'upload'
     }, $fh.__dest__.file);
-  };
-
-  $fh.push = function() {
-    handleargs(arguments, {}, $fh.__dest__.push);
   };
 
   // new functions


### PR DESCRIPTION
This fixes issue [RHMAP-2970](https://issues.jboss.org/browse/RHMAP-2970) as appforms is overriding the push api