### PR TITLE
decode the parameters in the url query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.16.2 - 2016-07-28 - Wei Li
+* RHMAP-5793 - Decode the parameters in the url query string.
+
 ## 2.16.1 - 2016-06-10 - Alan Moran
 
 * RHMAP-7618 - Client Form App - Submissions stuck in review when field is deleted from server side

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.16.1",
+  "version": "2.16.2",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/modules/appProps.js
+++ b/src/modules/appProps.js
@@ -15,7 +15,7 @@ var load = function(cb) {
   for(var key in url_params){
     if(url_params.hasOwnProperty(key) ){
       if(key.indexOf('fh_') === 0){
-        url_props[key.substr(3)] = url_params[key]; 
+        url_props[key.substr(3)] = decodeURI(url_params[key]); 
       }
     }
   }


### PR DESCRIPTION
decode config overrides when they are loaded via query string