### PR TITLE
Rhmap 10243 apply default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
+
+## 2.17.2 - 2016-11-08 - Niall Donnelly
+* RHMAP-10243 - Applying default values to new submissions.
+
 ## 2.17.1 - 2016-08-18 - Erik Jan de Wit
 * Use window object instead of this
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.1",
+  "version": "2.17.2",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -110,6 +110,9 @@ appForm.models = function(module) {
       this.set('filesInSubmission', []);
       this.set('deviceId', appForm.config.get('deviceId'));
       this.transactionMode = false;
+
+      //Applying default values from the form definition.
+      this.applyDefaultValues(form);
     } else {
       this.set('appId', appForm.config.get('appId'));
       if(params.submissionId){
@@ -420,6 +423,39 @@ appForm.models = function(module) {
         that.set('formFields', newFields);
         cb(err);
       });
+    });
+  };
+
+
+  /**
+   *
+   * Applying default values to a submission based on the form assigned to it.
+   *
+   * @param form - The form model to apply default values from
+   */
+  Submission.prototype.applyDefaultValues = function(form) {
+    var formFields = this.getFormFields();
+
+    //Have the form, need to apply default values to each of the fields.
+    _.each(form.fields, function(field, fieldId) {
+      var defaultValue = field.getDefaultValue();
+
+      //No default values for this field, don't need to do anything.
+      if(!defaultValue) {
+        return;
+      }
+
+      var formFieldEntry = _.findWhere(formFields, {fieldId: fieldId});
+
+      //If there is already an entry for this field, don't apply default values
+      //Otherwise, create a new entry and add the default values.
+      if(!formFieldEntry) {
+        formFields.push({
+          fieldId: fieldId,
+          fieldValues: [defaultValue]
+        });
+      }
+
     });
   };
 

--- a/src/appforms/src/core/040-Model07Field.js
+++ b/src/appforms/src/core/040-Model07Field.js
@@ -92,16 +92,78 @@ appForm.models = function (module) {
   */
   Field.prototype.getDefaultValue = function () {
     var def = this.getFieldDefinition();
-    if (def) {
+
+    //If the field is a multichoice field, then the selected option will be set in the options list.
+    if(this.isMultiChoiceField()) {
+      return this.getDefaultMultiValue();
+    } else {
       return def.defaultValue;
     }
-    return "";
+  };
+
+  /**
+   * Function to get the selected values for a multichoice fields
+   */
+  Field.prototype.getDefaultMultiValue = function() {
+    var fieldDefinition = this.getFieldDefinition();
+
+    if(!fieldDefinition.options) {
+      return null;
+    }
+
+    var selectedOptions = _.filter(fieldDefinition.options, function(option) {
+      return option.checked;
+    });
+
+    //No default options were selected.
+    if(_.isEmpty(selectedOptions)) {
+      return null;
+    }
+
+    selectedOptions = _.pluck(selectedOptions, 'label');
+
+    //Checkbox fields can have multiple inputs per field entry.
+    if(this.isCheckboxField()) {
+      return selectedOptions;
+    } else {
+      return _.first(selectedOptions);
+    }
   };
 
   Field.prototype.isAdminField = function(){
     return this.get("adminOnly");
   };
 
+  /**
+   * Checking if a field is a checkbox, radio or dropdown field type.
+   */
+  Field.prototype.isMultiChoiceField = function() {
+    return this.isCheckboxField() || this.isRadioField() || this.isDropdownField();
+  };
+
+  /**
+   * Checking if a field is a checkboxes field type
+   * @returns {boolean}
+   */
+  Field.prototype.isCheckboxField = function() {
+    return this.get('type') === 'checkboxes';
+  };
+
+  /**
+   * Checking if a field is a Radio field type
+   * @returns {boolean}
+   */
+  Field.prototype.isRadioField = function() {
+    return this.get('type') === 'radio';
+  };
+
+  /**
+   * Checking if a field is a Dropdown field type
+   * @returns {boolean}
+   */
+  Field.prototype.isDropdownField = function() {
+    return this.get('type') === 'dropdown';
+  };
 
   /**
      * Process an input value. convert to submission format. run field.validate before this

--- a/src/appforms/tests/tests/core/040-Model06Submission.js
+++ b/src/appforms/tests/tests/core/040-Model06Submission.js
@@ -99,6 +99,134 @@ describe("Submission model", function() {
 
         });
     });
+
+  it("A new submission should have default values set", function (done) {
+    var Form = appForm.models.Form;
+    var testDefaultValueForm = {
+      "_id": "58218fde6ec6d6aa36746758",
+      "name": "Test Default Value Form",
+      "createdBy": "testing-admin@example.com",
+      "pages": [{
+        "_id": "58218fde6ec6d6aa36746757",
+        "fields": [{
+          "required": true,
+          "type": "radio",
+          "name": "Rad",
+          "fieldCode": null,
+          "_id": "58218ffd6ec6d6aa36746759",
+          "adminOnly": false,
+          "fieldOptions": {
+            "validation": {"validateImmediately": true},
+            "definition": {
+              "options": [{"label": "Rad 1", "checked": false}, {
+                "label": "Rad 2",
+                "checked": false
+              }, {"checked": true, "name": "", "label": "Rad 3"}]
+            }
+          },
+          "repeating": false
+        }, {
+          "required": true,
+          "type": "dropdown",
+          "name": "Dropdown",
+          "_id": "58218ffd6ec6d6aa3674675a",
+          "adminOnly": false,
+          "fieldOptions": {
+            "definition": {
+              "options": [{"label": "Drop 1", "checked": false}, {"label": "Drop 2", "checked": true}],
+              "include_blank_option": false
+            }
+          },
+          "repeating": false
+        }, {
+          "required": true,
+          "type": "checkboxes",
+          "name": "Check",
+          "fieldCode": null,
+          "_id": "58218ffd6ec6d6aa3674675b",
+          "adminOnly": false,
+          "fieldOptions": {
+            "definition": {"options": [{"label": "Check 1", "checked": true}, {"label": "Check 2", "checked": true}]}
+          },
+          "repeating": false
+        }, {
+          "required": true,
+          "type": "text",
+          "name": "Text Field",
+          "_id": "53146c1f04e694ec1ad715b6",
+          "repeating": false,
+          "fieldOptions": {
+            definition: {defaultValue: "somedefaulttext"}
+          }
+        }, {
+          "required": true,
+          "type": "number",
+          "name": "Number Field",
+          "_id": "53146c1f04e694ec1ad71123",
+          "repeating": false,
+          "fieldOptions": {
+          }
+        }]
+      }],
+      "pageRef": {"58218fde6ec6d6aa36746757": 0},
+      "fieldRef": {
+        "58218ffd6ec6d6aa36746759": {"page": 0, "field": 0},
+        "58218ffd6ec6d6aa3674675a": {"page": 0, "field": 1},
+        "58218ffd6ec6d6aa3674675b": {"page": 0, "field": 2},
+        "53146c1f04e694ec1ad715b6": {"page": 0, "field": 3},
+        "53146c1f04e694ec1ad71123": {"page": 0, "field": 4}
+      }
+    };
+
+
+    new Form({
+      formId: "58218fde6ec6d6aa36746758",
+      rawMode: true,
+      rawData: testDefaultValueForm
+    }, function(err, formModel){
+      assert.ok(!err, "Expected no error when initialising the form " + err);
+
+      //Creating a new submission based on the form model
+      var submission = formModel.newSubmission();
+
+      //The default values should be set for the different field types.
+      var formFields = submission.getFormFields();
+
+      //The radio field should have the checked option added to the submission by default
+      var formField = _.findWhere(formFields, {fieldId: "58218ffd6ec6d6aa36746759"});
+
+      assert.ok(formField, "Expected a submission entry for the radio field.");
+      assert.equal("Rad 3", formField.fieldValues[0]);
+
+      //The dropdown field should have the checked option added to the submission by default
+      formField = _.findWhere(formFields, {fieldId: "58218ffd6ec6d6aa3674675a"});
+
+      assert.ok(formField, "Expected a submission entry for the dropdown field.");
+      assert.equal("Drop 2", formField.fieldValues[0]);
+
+      //The checkboxes field should have the checked options added to the submission by default
+      formField = _.findWhere(formFields, {fieldId: "58218ffd6ec6d6aa3674675b"});
+
+      assert.ok(formField, "Expected a submission entry for the checkbox field.");
+      //The checkbox entries are arrays as they can have multiple values.
+      assert.equal("Check 1", formField.fieldValues[0][0]);
+      assert.equal("Check 2", formField.fieldValues[0][1]);
+
+
+      //The text field should have the default value option added to the submission by default
+      formField = _.findWhere(formFields, {fieldId: "53146c1f04e694ec1ad715b6"});
+
+      assert.ok(formField, "Expected a submission entry for the text field.");
+      assert.equal("somedefaulttext", formField.fieldValues[0]);
+
+      //The number field should not have an entry as it has no default value.
+      formField = _.findWhere(formFields, {fieldId: "53146c1f04e694ec1ad71123"});
+
+      assert.ok(!formField, "Expected no submission entry for the number field.");
+      done();
+    });
+  });
+
     describe("comment", function() {
         it("how to add a comment to a submission with or without a user", function(done) {
             var meta = appForm.models.submissions.findByFormId(testData.formId)[0];


### PR DESCRIPTION
# Motivation

When a new submission is created with a form, it should automatically apply the default values for the field.

This is to ensure that any default values that affect rules are applied before testing rule values.

# Changes

- Added a `applyDefaultValues` function to the submission model. This is called when a new submission is initialised with a form.
- Added logic to the Field model to get default values from multi-choice and non-multichoice fields.