### PR TITLE
Bump to 2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.17.3 - 2016-11-09 - Niall Donnelly
+
+* Added pre-publish script to package.json to generate the dist folder.
+
 ## 2.17.2 - 2016-11-08 - Niall Donnelly
 * RHMAP-10243 - Applying default values to new submissions.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.2",
+  "version": "2.17.3",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {
@@ -46,7 +46,8 @@
     ]
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "prepublish": "grunt concat-core-sdk"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding a post install script to generate the dist folder when the fh-js-sdk has been installed.