### PR TITLE
Allowing users to get UIDs for sync records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.17.4 - 2016-11-09 - Niall Donnelly
+
+* Added getUID function to public $fh.sync API.
+
 ## 2.17.3 - 2016-11-09 - Niall Donnelly
 
 * Added pre-publish script to package.json to generate the dist folder.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.3",
+  "version": "2.17.4",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/modules/sync-cli.js
+++ b/src/modules/sync-cli.js
@@ -1278,6 +1278,7 @@ module.exports = {
   manage: self.manage,
   notify: self.notify,
   doList: self.list,
+  getUID: self.getUID,
   doCreate: self.create,
   doRead: self.read,
   doUpdate: self.update,


### PR DESCRIPTION
# Motivation

This allows users to check for sync records where `uid`s may have changed.

The changed `uid`s are emitted in notifications and any function filtering on the old `uid` will not filter correctly.