### PR TITLE
Rhmap 11349 dont submit hidden values

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.4",
+  "version": "2.17.5",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {


### PR DESCRIPTION
# Motivation

When a form is being submitted, any hidden fields with values also get submitted.

These values in hidden fields should be removed.

# Changes

- Added a `removeHiddenFieldValues` function to remove any hidden field values.