### PR TITLE
Rhmap 11844 fix auth in studio preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.17.6 - 2016-11-23 - Alan Moran
+
+* Allow $fh.auth to work from studio preview
+
 ## 2.17.4 - 2016-11-09 - Niall Donnelly
 
 * Added getUID function to public $fh.sync API.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.17.5",
+  "version": "2.17.6",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "browser": {

--- a/src/modules/api_auth.js
+++ b/src/modules/api_auth.js
@@ -17,6 +17,12 @@ function callAuthEndpoint(endpoint, data, opts, success, fail){
     path = cloud.getCloudHostUrl() + constants.boxprefix + "admin/authpolicy/" + endpoint;
   }
 
+  // Detect if app is being previewed in the studio
+  // If so, don't use cloud host URL as $fh.auth will get 404
+  if(app_props.studio){
+    path = document.location.origin + constants.boxprefix + "admin/authpolicy/" + endpoint;
+  }
+
   ajax({
     "url": path,
     "type": "POST",
@@ -62,7 +68,7 @@ var auth = function(opts, success, fail) {
       req.clientToken = opts.clientToken;
       var cloudHost = cloud.getCloudHost();
       if(cloudHost.getEnv()){
-        req.environment = cloudHost.getEnv(); 
+        req.environment = cloudHost.getEnv();
       }
       if (opts.endRedirectUrl) {
         req.endRedirectUrl = opts.endRedirectUrl;

--- a/src/modules/appProps.js
+++ b/src/modules/appProps.js
@@ -10,16 +10,16 @@ var load = function(cb) {
   var doc_url = document.location.href;
   var url_params = qs(doc_url.replace(/#.*?$/g, ''));
   var url_props = {};
-  
+
   //only use fh_ prefixed params
   for(var key in url_params){
     if(url_params.hasOwnProperty(key) ){
       if(key.indexOf('fh_') === 0){
-        url_props[key.substr(3)] = decodeURI(url_params[key]); 
+        url_props[key.substr(3)] = decodeURI(url_params[key]);
       }
     }
   }
-  
+
   //default properties
   app_props = {
     appid: "000000000000000000000000",
@@ -27,14 +27,15 @@ var load = function(cb) {
     projectid: "000000000000000000000000",
     connectiontag: "0.0.1"
   };
-  
+
   function setProps(props){
     _.extend(app_props, props, url_props);
-    
+
     if(typeof url_params.url !== 'undefined'){
-     app_props.host = url_params.url; 
+     app_props.host = url_params.url;
     }
-    
+
+    app_props.studio = (url_props.destination_code === 'studio');
     app_props.local = !!(url_props.host || url_params.url);
     cb(null, app_props);
   }


### PR DESCRIPTION
Currently, in the studio preview the JS $fh.auth call fails. This is due to the request path being the cloud url and not the studio url.

- I've added a new app prop to identify the app is running in the studio
- Fix auth request url if running from the studio