### PR TITLE
[WIP][RAINCATCH-278] Support standalone client for load-testing raincatcher-sync

### DIFF
--- a/src/modules/appProps.js
+++ b/src/modules/appProps.js
@@ -40,17 +40,17 @@ var load = function(cb) {
   }
 
   var config_url = url_params.fhconfig || consts.config_js;
-  ajax({
+  //fh v2 only
+  if(window.fh_app_props) {
+    return setProps(window.fh_app_props);
+  }
+  var ajaxOpts = {
     url: config_url,
     dataType: "json",
     success: function(data) {
       logger.debug("fhconfig = " + JSON.stringify(data));
       //when load the config file on device, because file:// protocol is used, it will never call fail call back. The success callback will be called but the data value will be null.
       if (null == data) {
-        //fh v2 only
-        if(window.fh_app_props){
-          return setProps(window.fh_app_props);
-        }
         return cb(new Error("app_config_missing"));
       } else {
 
@@ -58,14 +58,11 @@ var load = function(cb) {
       }
     },
     error: function(req, statusText, error) {
-      //fh v2 only
-      if(window.fh_app_props){
-        return setProps(window.fh_app_props);
-      }
       logger.error(consts.config_js + " Not Found");
       cb(new Error("app_config_missing"));
     }
-  });
+  };
+  ajax(ajaxOpts);
 };
 
 var setAppProps = function(props) {

--- a/src/modules/data.js
+++ b/src/modules/data.js
@@ -7,7 +7,7 @@ var data = {
   //dom adapter doens't work on windows phone, so don't specify the adapter if the dom one failed
   //we specify the order of lawnchair adapters to use, lawnchair will find the right one to use, to keep backward compatibility, keep the order
   //as dom, webkit-sqlite, localFileStorage, window-name
-  DEFAULT_ADAPTERS : ["dom", "webkit-sqlite", "window-name", "titanium"],
+  DEFAULT_ADAPTERS : ["dom", "webkit-sqlite", "window-name", "titanium", "memory"],
   getStorage: function(name, adapters, fail){
     var adpts = data.DEFAULT_ADAPTERS;
     var errorHandler = fail || function(){};


### PR DESCRIPTION
# Reason
Small changes to support the load-testing initiative for Raincatcher. Specifically running outside of a regular or headless browser.

# Changes
* Avoid xhr call when overriding locally through `window.fh_app_props`
* Also add `memory` as a last fallback adapter for Lawnchair

WIP, version bump pending
ping @nialldonnellyfh is specifically the ajax change acceptable?

Seems like the window property is legacy, but it proved a useful tool for running the sdk outside of a browser (on `jsdom` the ajax call always results on some kind of malformed request exception I couldn't get around, but it would also contribute to load-test performance)