### PR TITLE
Raincatch 131 Building full submission state for forms.

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "grunt-text-replace": "0.3.12",
     "grunt-zip": "0.12.0",
     "mocha": "1.17.1",
+    "moment": "^2.17.1",
     "sinon": "1.9.0",
     "sinon-chai": "2.5.0",
     "through": "2.3.4"

--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -1202,7 +1202,7 @@ appForm.models = function(module) {
 
       self.submissionState.pages = _.map(self.submissionState.pages, function(page) {
         page.fields = _.map(page.fields, function(field) {
-          var formField = _.find(formFields, {_id: field._id});
+          var formField = _.findWhere(formFields, {fieldId: field._id});
 
           if (!formField) {
             formField = {
@@ -1219,7 +1219,6 @@ appForm.models = function(module) {
           //TODO Repeating Fields.
           field.updateValue = function() {
             this.values[0] = this.value;
-
           };
 
           // updates value of file type fields
@@ -1242,6 +1241,7 @@ appForm.models = function(module) {
       return cb(undefined, self.submissionState);
     });
   };
+
 
   Submission.prototype.getRemoteSubmissionId = function() {
     return this.get("submissionId") || this.get('_id');

--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -1208,7 +1208,7 @@ appForm.models = function(module) {
             formField = {
               fieldId: field._id,
               fieldValues: []
-              //Utility funtion to update the value
+              //Utility function to update the value
             };
             formFields.push(formField);
           }
@@ -1219,6 +1219,18 @@ appForm.models = function(module) {
           //TODO Repeating Fields.
           field.updateValue = function() {
             this.values[0] = this.value;
+
+          };
+
+          // updates value of file type fields
+          field.addFileValue = function(cb) {
+            var params = {
+              fieldId: this._id,
+              value: this.value
+            };
+            self.addInputValue(params, function(err, result) {
+              cb(err, result);
+            });
           };
 
           return field;

--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -1165,6 +1165,72 @@ appForm.models = function(module) {
       });
     });
   };
+
+  /**
+   * Function to build the full state of the form.
+   *
+   * This makes it easier for users to integrage the submission state into external applications
+   *
+   * TODO Apply Default Values
+   * TODO Repeating Fields
+   * TODO Applying Rule Values
+   *
+   * This includes:
+   *
+   *   - The current state of all pages and fields. (Whether they are hidden by rules)
+   *   - The current values in the field
+   *
+   */
+  Submission.prototype.buildFullSubmissionState = function(cb) {
+    var self = this;
+
+    //If there is already an active submission state, then there is no need to build it again
+    if (self.submissionState) {
+      return cb(undefined, self.submissionState);
+    }
+
+    //Getting the current values in the submission
+    var formFields = self.getFormFields();
+
+    self.getForm(function(err, form) {
+      if(err) {
+        return cb(err);
+      }
+
+      //Need to merge the form definition with the current value of the submissions.
+      self.submissionState = form.toJSON();
+
+      self.submissionState.pages = _.map(self.submissionState.pages, function(page) {
+        page.fields = _.map(page.fields, function(field) {
+          var formField = _.find(formFields, {_id: field._id});
+
+          if (!formField) {
+            formField = {
+              fieldId: field._id,
+              fieldValues: []
+              //Utility funtion to update the value
+            };
+            formFields.push(formField);
+          }
+
+          field.values = formField.fieldValues;
+
+          //Function for updating a value in a field.
+          //TODO Repeating Fields.
+          field.updateValue = function() {
+            this.values[0] = this.value;
+          };
+
+          return field;
+        });
+
+        return page;
+      });
+
+      return cb(undefined, self.submissionState);
+    });
+  };
+
   Submission.prototype.getRemoteSubmissionId = function() {
     return this.get("submissionId") || this.get('_id');
   };


### PR DESCRIPTION
# Overview

This branch incorporates the changes required to simplify the mapping for fields / pages / sections in a form to views.

# Motiviation

Currently, the structure of the form and the submission values are maintained in separate models.

This complicates the process of rendering forms and adding values as it leaves the merging of fields and values to the view logic.

This adds further complications as state changes requiring view updates (e.g. a field value was invalid requiring a message to be displayed to the user) requires the view logic to find the field and assign the error.

It should be the responsibility of the $fh.forms Core SDK to update the current form state. These changes can then be simply rendered by the UI framework. (e.g. AngularJS, Backbone etc)

# Changes

The Submission model includes a new function `buildFullSubmissionState`. This function merges the state data for the field (e.g. required, name, instructions) with the current values assigned to the submission.

Each field includes a `addValue` function to add a value to the field using the `addInputValue` function in the Submission model. This ensures that the correct value conversions and validations are performed when adding the value (e.g. if a file is being saved the file is copied to the file system etc)