### PR TITLE
Rhmap 12426 fix section dropdown

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "dependencies": {
     "loglevel": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",

--- a/src/appforms/src/core/040-Model08Page.js
+++ b/src/appforms/src/core/040-Model08Page.js
@@ -2,6 +2,7 @@
  * One form contains multiple pages
  */
 appForm.models = function (module) {
+
   var Model = appForm.models.Model;
   function Page(opt, parentForm) {
     if (typeof opt === 'undefined' || typeof parentForm === 'undefined') {
@@ -50,12 +51,23 @@ appForm.models = function (module) {
     }
     return false;
   };
+
+
+  /**
+   * Getting a list of sections for this page if the page contains any section breaks.
+   *
+   *
+   * @returns {*}
+   */
   Page.prototype.getSections=function(){ //Checking for any sections
     var sectionList={};
-    var currentSection = null;
+    var currentSectionId = null;
     var sectionBreaksExist = this.checkForSectionBreaks();
     var insertSectionBreak = false;
 
+    var pageId = this.get("_id");
+
+    //If there is a single section break in the page, then we need to render section breaks.
     if(sectionBreaksExist){
       //If there are section breaks, the first field in the form must be a section break. If not, add a placeholder
       var firstField = this.form.getFieldModelById(this.fieldsIds[0]);
@@ -64,28 +76,30 @@ appForm.models = function (module) {
         insertSectionBreak = true;
       }
     } else {
+      //No section breaks exist in the page, so no need to render any section breaks.
+      //We can just render the fields.
       return null;
     }
 
-    for (var i=0;i<this.fieldsIds.length;i++){
-      var fieldModel = this.form.getFieldModelById(this.fieldsIds[i]);
+    //Iterating through the fields in the page and building a list of section breaks as required.
+    for (var fieldModelIndex = 0; fieldModelIndex < this.fieldsIds.length; fieldModelIndex++){
+      var fieldModel = this.form.getFieldModelById(this.fieldsIds[fieldModelIndex]);
 
-      if(insertSectionBreak && i === 0){ //Adding a first section.
-        currentSection = "sectionBreak" + i;
-        sectionList[currentSection] = sectionList[currentSection] ? sectionList[currentSection] : {fields: []};
-        sectionList[currentSection].title = "Section " + (i+1);
+      if(insertSectionBreak && fieldModelIndex === 0){ //Adding a first section.
+        currentSectionId = "sectionBreak" + pageId + "0";
+        sectionList[currentSectionId] = sectionList[currentSectionId] ? sectionList[currentSectionId] : {fields: []};
+        sectionList[currentSectionId].title = "Section " + (fieldModelIndex+1);
       }
 
-      if(currentSection !== null && fieldModel.getType() !== "sectionBreak"){
-        sectionList[currentSection].fields.push(fieldModel);
+      if(currentSectionId !== null && fieldModel.getType() !== "sectionBreak"){
+        sectionList[currentSectionId].fields.push(fieldModel);
       }
 
       if(fieldModel.getType() === "sectionBreak"){
-        currentSection = "sectionBreak" + i;
-        sectionList[currentSection] = sectionList[currentSection] ? sectionList[currentSection] : {fields: []};
-        sectionList[currentSection].title = fieldModel.get('name', "Section " + (i+1));
-        sectionList[currentSection].description = fieldModel.get('helpText', "Section " + (i+1));
-        sectionList[currentSection].fields.push(fieldModel);
+        currentSectionId = fieldModel.get('_id');
+        sectionList[currentSectionId] = sectionList[currentSectionId] ? sectionList[currentSectionId] : {fields: []};
+        sectionList[currentSectionId].title = fieldModel.get('name', "Section " + (fieldModelIndex+1));
+        sectionList[currentSectionId].description = fieldModel.get('helpText', "Section " + (fieldModelIndex+1));
       }
     }
 

--- a/src/appforms/tests/tests/core/040-Model08Page.js
+++ b/src/appforms/tests/tests/core/040-Model08Page.js
@@ -155,6 +155,6 @@ describe("Page model", function() {
       });
     });
 
-    
+
   });
 });

--- a/src/appforms/tests/tests/core/040-Model08Page.js
+++ b/src/appforms/tests/tests/core/040-Model08Page.js
@@ -44,4 +44,117 @@ describe("Page model", function() {
         done();
       });
     });
+
+  describe("Section Breaks", function() {
+
+    function getSectionBreakFormJSON(formId, includeFirstSection) {
+
+      var firstSectionBreak = {
+        _id: "sectionid1",
+        type: "sectionBreak",
+        name: "Section 1",
+        description: "This is section 1"
+      };
+
+      var form = {
+        "_id": formId,
+        "name": "Test Default Value Form",
+        "createdBy": "testing-admin@example.com",
+        "pages": [{
+          _id: "page1id",
+          name: "This is page 1",
+          fields: [
+            {
+              _id: "fieldid1",
+              type: "text",
+              name: "Text Field",
+              description: "This is a text field in section 1"
+            },
+            {
+              _id: "sectionid2",
+              type: "sectionBreak",
+              name: "Section 2",
+              description: "This is section 2 in page 1"
+            },
+            {
+              _id: "numberfieldid",
+              type: "number",
+              name: "Number Field",
+              description: "This is a number field in section 2"
+            }
+          ]
+        }],
+        "pageRef": {"page1id": 0},
+        "fieldRef": {
+          "sectionid1": {"page": 0, "field": 0},
+          "fieldid1": {"page": 0, "field": 1},
+          "sectionid2": {"page": 0, "field": 2},
+          "numberfieldid": {"page": 0, "field": 3}
+        }
+      };
+
+      if(includeFirstSection) {
+        form.pages[0].fields.unshift(firstSectionBreak);
+      }
+
+
+      return form;
+    }
+
+    it("pages should return unique section IDs", function(done) {
+
+      var formId = "sectionbreakformid";
+      var sectionBreakForm = getSectionBreakFormJSON(formId, true);
+
+      var Form = appForm.models.Form;
+
+      new Form({
+        formId: formId,
+        rawMode: true,
+        rawData: sectionBreakForm
+      }, function(err, formModel) {
+        assert.ok(!err, "Expected no error intialising form");
+
+        var pageModel = formModel.getPageModelById("page1id");
+
+        var sections = pageModel.getSections();
+
+        var expectedSection1Id = "sectionid1";
+        var expectedSection2Id = "sectionid2";
+
+        assert.equal("fieldid1", sections[expectedSection1Id].fields[0].getFieldId());
+        assert.equal("numberfieldid", sections[expectedSection2Id].fields[0].getFieldId());
+        done();
+      });
+    });
+
+    it("pages should add a default section first if not specified", function(done) {
+
+      var formId = "sectionbreakformidnofirstsection";
+      var sectionBreakForm = getSectionBreakFormJSON(formId, false);
+
+      var Form = appForm.models.Form;
+
+      new Form({
+        formId: formId,
+        rawMode: true,
+        rawData: sectionBreakForm
+      }, function(err, formModel) {
+        assert.ok(!err, "Expected no error intialising form");
+
+        var pageModel = formModel.getPageModelById("page1id");
+
+        var sections = pageModel.getSections();
+
+        var expectedSection1Id = "sectionBreakpage1id0";
+        var expectedSection2Id = "sectionid2";
+
+        assert.equal("fieldid1", sections[expectedSection1Id].fields[0].getFieldId());
+        assert.equal("numberfieldid", sections[expectedSection2Id].fields[0].getFieldId());
+        done();
+      });
+    });
+
+    
+  });
 });


### PR DESCRIPTION
# Motivation

The section break IDs returned from a page were not guaranteed to be unique across multiple pages.

This change ensures that the section IDs returned from a page are unique.

# Changes

Updated the `getSections` function for the `Page` model to assign the field ID of the section field as the ID. All field IDs are guaranteed to be unique.

