### PR TITLE
RAINCATCH-570 - update to the new browser api

### DIFF
--- a/libs/lawnchair/lawnchairHtml5FileSystem.js
+++ b/libs/lawnchair/lawnchairHtml5FileSystem.js
@@ -1,30 +1,7 @@
 Lawnchair.adapter('html5-filesystem', (function(global){
   
   var fail = function( e ) {
-    var msg;
-    var show = true;
-    switch (e.name) {
-      case "QuotaExceededError":
-        msg = 'QUOTA_EXCEEDED_ERR';
-        break;
-      case "NotFoundError":
-        msg = 'NOT_FOUND_ERR';
-        show = false;
-        break;
-      case "SecurityError":
-        msg = 'SECURITY_ERR';
-        break;
-      case "InvalidModificationError":
-        msg = 'INVALID_MODIFICATION_ERR';
-        break;
-      case "InvalidStateError":
-        msg = 'INVALID_STATE_ERR';
-        break;
-      default:
-        msg = 'Unknown Error';
-        break;
-    };
-    if ( console && show ) console.error( e, msg );
+    if ( console ) console.error(e, e.name);
   };
 
   var ls = function( reader, callback, entries ) {

--- a/libs/lawnchair/lawnchairHtml5FileSystem.js
+++ b/libs/lawnchair/lawnchairHtml5FileSystem.js
@@ -1,25 +1,23 @@
 Lawnchair.adapter('html5-filesystem', (function(global){
-
-  var FileError = global.FileError;
-
+  
   var fail = function( e ) {
     var msg;
     var show = true;
-    switch (e.code) {
-      case FileError.QUOTA_EXCEEDED_ERR:
+    switch (e.name) {
+      case "QuotaExceededError":
         msg = 'QUOTA_EXCEEDED_ERR';
         break;
-      case FileError.NOT_FOUND_ERR:
+      case "NotFoundError":
         msg = 'NOT_FOUND_ERR';
         show = false;
         break;
-      case FileError.SECURITY_ERR:
+      case "SecurityError":
         msg = 'SECURITY_ERR';
         break;
-      case FileError.INVALID_MODIFICATION_ERR:
+      case "InvalidModificationError":
         msg = 'INVALID_MODIFICATION_ERR';
         break;
-      case FileError.INVALID_STATE_ERR:
+      case "InvalidStateError":
         msg = 'INVALID_STATE_ERR';
         break;
       default:


### PR DESCRIPTION
# Motivation

FileError is obsolete and was removed in most recent versions of the mobile browsers:
https://developer.mozilla.org/en-US/docs/Web/API/FileError

This fix removes error I have seen when testing sample app. I did not seen any other errors and rest of the html5 filesystem api seems to be working fine. However Lawnchair library is fairly outdated and it would be better to update it for better future browser support.

ping @david-martin @wei-lee 

More information in ticket: https://issues.jboss.org/browse/RAINCATCH-570
