### PR TITLE
Recreate mock_uuid cookie if blank string

### DIFF
--- a/src/modules/device.js
+++ b/src/modules/device.js
@@ -15,9 +15,9 @@ module.exports = {
     } else {
       var _mock_uuid_cookie_name = "mock_uuid";
       var uuid = cookies.readCookieValue(_mock_uuid_cookie_name);
-      if(null == uuid){
-          uuid = uuidModule.createUUID();
-          cookies.createCookie(_mock_uuid_cookie_name, uuid);
+      if(!uuid){
+        uuid = uuidModule.createUUID();
+        cookies.createCookie(_mock_uuid_cookie_name, uuid);
       }
       return uuid;
     }


### PR DESCRIPTION
Currently when the value of a cookie is blank it is read as an empty
string. This passes the current check that is looking for the value
being `null`. If the value is `null` the cookie will be recreated.

This behaviour will cause fh-mbaas-api to throw an error, as it checks
whether the CUID sent from the client is a falsy value. If it is, it will produce
an error and fail to process the pending record.

This changes the check on the client SDK to match that of fh-mbaas-api
so that empty-string device ids will be recreated as well as `null` ones.