### PR TITLE
add browserify-shim as a dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,25 +2,818 @@
   "name": "fh-js-sdk",
   "version": "2.18.6",
   "dependencies": {
+    "acorn": {
+      "version": "4.0.13",
+      "from": "acorn@>=4.0.3 <5.0.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "from": "amdefine@>=0.0.4",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+    },
+    "assert": {
+      "version": "1.1.2",
+      "from": "assert@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.1.2.tgz"
+    },
+    "astw": {
+      "version": "2.2.0",
+      "from": "astw@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz"
+    },
+    "async": {
+      "version": "0.2.10",
+      "from": "async@>=0.2.6 <0.3.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+    },
+    "Base64": {
+      "version": "0.2.1",
+      "from": "Base64@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+    },
+    "base64-js": {
+      "version": "0.0.8",
+      "from": "base64-js@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+    },
+    "browser-pack": {
+      "version": "2.0.1",
+      "from": "browser-pack@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-2.0.1.tgz",
+      "dependencies": {
+        "JSONStream": {
+          "version": "0.6.4",
+          "from": "JSONStream@>=0.6.4 <0.7.0",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.2.7",
+              "from": "through@>=2.2.7 <2.3.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "from": "through@>=2.3.4 <2.4.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        }
+      }
+    },
+    "browser-resolve": {
+      "version": "1.2.4",
+      "from": "browser-resolve@>=1.2.1 <1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz"
+    },
+    "browserify": {
+      "version": "3.46.1",
+      "from": "browserify@3.46.1",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-3.46.1.tgz",
+      "dependencies": {
+        "process": {
+          "version": "0.7.0",
+          "from": "process@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.7.0.tgz"
+        },
+        "string_decoder": {
+          "version": "0.0.1",
+          "from": "string_decoder@>=0.0.0 <0.1.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.0.1.tgz"
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "from": "xtend@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+        }
+      }
+    },
+    "browserify-shim": {
+      "version": "3.3.2",
+      "from": "browserify-shim@>=3.3.2 <3.4.0",
+      "resolved": "https://registry.npmjs.org/browserify-shim/-/browserify-shim-3.3.2.tgz",
+      "dependencies": {
+        "through": {
+          "version": "2.3.8",
+          "from": "through@>=2.3.4 <2.4.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        }
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "from": "browserify-zlib@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+    },
+    "buffer": {
+      "version": "2.1.13",
+      "from": "buffer@>=2.1.4 <2.2.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-2.1.13.tgz"
+    },
+    "builtins": {
+      "version": "0.0.7",
+      "from": "builtins@>=0.0.3 <0.1.0",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz"
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "from": "callsite@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "from": "camelcase@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+    },
+    "combine-source-map": {
+      "version": "0.3.0",
+      "from": "combine-source-map@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.3.0.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.31 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
+        }
+      }
+    },
+    "commondir": {
+      "version": "0.0.1",
+      "from": "commondir@0.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-0.0.1.tgz"
+    },
+    "concat-stream": {
+      "version": "1.4.10",
+      "from": "concat-stream@>=1.4.1 <1.5.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        }
+      }
+    },
+    "console-browserify": {
+      "version": "1.0.3",
+      "from": "console-browserify@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.0.3.tgz"
+    },
+    "constants-browserify": {
+      "version": "0.0.1",
+      "from": "constants-browserify@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+    },
+    "convert-source-map": {
+      "version": "0.3.5",
+      "from": "convert-source-map@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "crypto-browserify": {
+      "version": "1.0.9",
+      "from": "crypto-browserify@>=1.0.9 <1.1.0",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-1.0.9.tgz"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "from": "decamelize@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+    },
+    "deep-equal": {
+      "version": "0.1.2",
+      "from": "deep-equal@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.1.2.tgz"
+    },
+    "defined": {
+      "version": "0.0.0",
+      "from": "defined@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz"
+    },
+    "deps-sort": {
+      "version": "0.1.2",
+      "from": "deps-sort@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-0.1.2.tgz",
+      "dependencies": {
+        "JSONStream": {
+          "version": "0.6.4",
+          "from": "JSONStream@>=0.6.4 <0.7.0",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.6.4.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.2.7",
+              "from": "through@>=2.2.7 <2.3.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz"
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "from": "through@~2.3.4",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        }
+      }
+    },
+    "derequire": {
+      "version": "0.8.0",
+      "from": "derequire@>=0.8.0 <0.9.0",
+      "resolved": "https://registry.npmjs.org/derequire/-/derequire-0.8.0.tgz",
+      "dependencies": {
+        "esprima-fb": {
+          "version": "3001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@>=3001.1.0-dev-harmony-fb <3002.0.0",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+        }
+      }
+    },
+    "detective": {
+      "version": "2.3.0",
+      "from": "detective@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-2.3.0.tgz"
+    },
+    "domain-browser": {
+      "version": "1.1.7",
+      "from": "domain-browser@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "from": "duplexer@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "from": "duplexer2@0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@~1.1.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        }
+      }
+    },
+    "escodegen": {
+      "version": "0.0.15",
+      "from": "escodegen@0.0.15",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.15.tgz"
+    },
+    "escope": {
+      "version": "0.0.16",
+      "from": "escope@>=0.0.13 <0.1.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-0.0.16.tgz"
+    },
+    "esprima": {
+      "version": "1.0.2",
+      "from": "esprima@1.0.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.2.tgz"
+    },
+    "esrefactor": {
+      "version": "0.1.0",
+      "from": "esrefactor@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/esrefactor/-/esrefactor-0.1.0.tgz",
+      "dependencies": {
+        "estraverse": {
+          "version": "0.0.4",
+          "from": "estraverse@>=0.0.4 <0.1.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-0.0.4.tgz"
+        }
+      }
+    },
+    "estraverse": {
+      "version": "1.5.1",
+      "from": "estraverse@>=1.5.0 <1.6.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz"
+    },
+    "esutils": {
+      "version": "1.0.0",
+      "from": "esutils@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz"
+    },
+    "events": {
+      "version": "1.0.2",
+      "from": "events@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+    },
+    "exposify": {
+      "version": "0.1.5",
+      "from": "exposify@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/exposify/-/exposify-0.1.5.tgz"
+    },
+    "find-parent-dir": {
+      "version": "0.2.1",
+      "from": "find-parent-dir@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.2.1.tgz"
+    },
+    "glob": {
+      "version": "3.2.11",
+      "from": "glob@>=3.2.8 <3.3.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz"
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "2.0.3",
+      "from": "graceful-fs@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+    },
+    "has-require": {
+      "version": "1.1.0",
+      "from": "has-require@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/has-require/-/has-require-1.1.0.tgz"
+    },
+    "http-browserify": {
+      "version": "1.3.2",
+      "from": "http-browserify@>=1.3.1 <1.4.0",
+      "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.3.2.tgz"
+    },
+    "https-browserify": {
+      "version": "0.0.1",
+      "from": "https-browserify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "from": "ieee754@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "from": "indexof@0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "from": "inherits@>=2.0.1 <2.1.0",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "inline-source-map": {
+      "version": "0.3.1",
+      "from": "inline-source-map@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.3.1.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.3.0",
+          "from": "source-map@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.3.0.tgz"
+        }
+      }
+    },
+    "insert-module-globals": {
+      "version": "6.0.0",
+      "from": "insert-module-globals@>=6.0.0 <6.1.0",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-6.0.0.tgz",
+      "dependencies": {
+        "through": {
+          "version": "2.3.8",
+          "from": "through@~2.3.4",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "from": "xtend@^3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+        }
+      }
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "from": "isarray@0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+    },
+    "jsonparse": {
+      "version": "0.0.5",
+      "from": "jsonparse@0.0.5",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz"
+    },
+    "JSONStream": {
+      "version": "0.7.4",
+      "from": "JSONStream@>=0.7.1 <0.8.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+      "dependencies": {
+        "through": {
+          "version": "2.3.8",
+          "from": "through@>=2.2.7 <3",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        }
+      }
+    },
+    "lexical-scope": {
+      "version": "1.1.1",
+      "from": "lexical-scope@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.1.1.tgz"
+    },
     "loglevel": {
       "version": "0.6.0",
       "from": "loglevel@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-0.6.0.tgz"
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "from": "lru-cache@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "from": "minimatch@>=0.2.12 <0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "from": "minimist@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+    },
+    "module-deps": {
+      "version": "2.0.6",
+      "from": "module-deps@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-2.0.6.tgz",
+      "dependencies": {
+        "detective": {
+          "version": "3.1.0",
+          "from": "detective@>=3.1.0 <3.2.0",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz"
+        },
+        "escodegen": {
+          "version": "1.1.0",
+          "from": "escodegen@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "esprima-fb": {
+          "version": "3001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+        },
+        "parents": {
+          "version": "0.0.2",
+          "from": "parents@0.0.2",
+          "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.2.tgz"
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@~0.1.30",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "optional": true
+        },
+        "stream-combiner": {
+          "version": "0.1.0",
+          "from": "stream-combiner@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.1.0.tgz"
+        },
+        "through": {
+          "version": "2.3.8",
+          "from": "through@~2.3.4",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        }
+      }
+    },
+    "mothership": {
+      "version": "0.1.0",
+      "from": "mothership@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/mothership/-/mothership-0.1.0.tgz"
+    },
+    "object-keys": {
+      "version": "0.4.0",
+      "from": "object-keys@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+    },
+    "optimist": {
+      "version": "0.3.7",
+      "from": "optimist@>=0.3.5 <0.4.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+    },
+    "os-browserify": {
+      "version": "0.1.2",
+      "from": "os-browserify@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+    },
+    "pako": {
+      "version": "0.2.9",
+      "from": "pako@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+    },
+    "parents": {
+      "version": "0.0.3",
+      "from": "parents@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-0.0.3.tgz"
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "from": "path-browserify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+    },
+    "path-platform": {
+      "version": "0.0.1",
+      "from": "path-platform@>=0.0.1 <0.0.2",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.0.1.tgz"
     },
     "process": {
       "version": "0.6.0",
       "from": "process@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/process/-/process-0.6.0.tgz"
     },
+    "punycode": {
+      "version": "1.2.4",
+      "from": "punycode@>=1.2.3 <1.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.2.4.tgz"
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "from": "querystring@0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+    },
+    "querystring-es3": {
+      "version": "0.2.0",
+      "from": "querystring-es3@0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.0.tgz"
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "from": "readable-stream@>=1.0.17 <1.1.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+    },
+    "readdirp": {
+      "version": "0.3.3",
+      "from": "readdirp@>=0.3.3 <0.4.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-0.3.3.tgz"
+    },
+    "rename-function-calls": {
+      "version": "0.1.1",
+      "from": "rename-function-calls@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/rename-function-calls/-/rename-function-calls-0.1.1.tgz",
+      "dependencies": {
+        "detective": {
+          "version": "3.1.0",
+          "from": "detective@>=3.1.0 <3.2.0",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-3.1.0.tgz"
+        },
+        "escodegen": {
+          "version": "1.1.0",
+          "from": "escodegen@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.1.0.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@>=1.0.4 <1.1.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "esprima-fb": {
+          "version": "3001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@3001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz"
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.30 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "optional": true
+        }
+      }
+    },
+    "resolve": {
+      "version": "0.6.3",
+      "from": "resolve@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz"
+    },
+    "rfile": {
+      "version": "1.0.0",
+      "from": "rfile@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/rfile/-/rfile-1.0.0.tgz",
+      "dependencies": {
+        "resolve": {
+          "version": "0.3.1",
+          "from": "resolve@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.3.1.tgz"
+        }
+      }
+    },
+    "ruglify": {
+      "version": "1.0.0",
+      "from": "ruglify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/ruglify/-/ruglify-1.0.0.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@~0.1.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
+        },
+        "uglify-js": {
+          "version": "2.2.5",
+          "from": "uglify-js@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz"
+        }
+      }
+    },
+    "shallow-copy": {
+      "version": "0.0.1",
+      "from": "shallow-copy@0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+    },
+    "shell-quote": {
+      "version": "0.0.1",
+      "from": "shell-quote@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-0.0.1.tgz"
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "from": "sigmund@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "from": "source-map@>=0.1.2",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "optional": true
+    },
+    "stream-browserify": {
+      "version": "0.1.3",
+      "from": "stream-browserify@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-0.1.3.tgz",
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "from": "process@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
+        }
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "from": "stream-combiner@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+    },
+    "subarg": {
+      "version": "0.0.1",
+      "from": "subarg@0.0.1",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-0.0.1.tgz"
+    },
+    "syntax-error": {
+      "version": "1.1.6",
+      "from": "syntax-error@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.6.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "from": "acorn@>=2.7.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz"
+        }
+      }
+    },
+    "through2": {
+      "version": "0.4.2",
+      "from": "through2@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz"
+    },
+    "timers-browserify": {
+      "version": "1.0.3",
+      "from": "timers-browserify@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.0.3.tgz",
+      "dependencies": {
+        "process": {
+          "version": "0.5.2",
+          "from": "process@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz"
+        }
+      }
+    },
+    "transformify": {
+      "version": "0.1.2",
+      "from": "transformify@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/transformify/-/transformify-0.1.2.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        }
+      }
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "from": "tty-browserify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+    },
     "type-of": {
       "version": "2.0.1",
       "from": "type-of@>=2.0.1 <2.1.0",
       "resolved": "https://registry.npmjs.org/type-of/-/type-of-2.0.1.tgz"
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "from": "typedarray@>=0.0.5 <0.1.0",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+    },
+    "uglify-js": {
+      "version": "2.4.24",
+      "from": "uglify-js@>=2.4.0 <2.5.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.24.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.34",
+          "from": "source-map@0.1.34",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz"
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+    },
+    "umd": {
+      "version": "2.0.0",
+      "from": "umd@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-2.0.0.tgz",
+      "dependencies": {
+        "through": {
+          "version": "2.3.8",
+          "from": "through@~2.3.4",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        }
+      }
+    },
     "underscore": {
       "version": "1.6.0",
       "from": "underscore@>=1.6.0 <1.7.0",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+    },
+    "url": {
+      "version": "0.10.3",
+      "from": "url@>=0.10.1 <0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "from": "punycode@1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+        }
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "from": "util@>=0.10.1 <0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        }
+      }
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "from": "vm-browserify@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "from": "wordwrap@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+    },
+    "xtend": {
+      "version": "2.1.2",
+      "from": "xtend@>=2.1.1 <2.2.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz"
+    },
+    "yargs": {
+      "version": "3.5.4",
+      "from": "yargs@>=3.5.4 <3.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,15 +62,15 @@
   "license": "Copyright (c) 2014 FeedHenry Ltd, All Rights Reserved.",
   "gitHead": "251a1f88a39f59f2652552ae245893a833faee71",
   "dependencies": {
-    "type-of": "~2.0.1",
+    "browserify": "3.46.1",
+    "browserify-shim": "~3.3.2",
     "loglevel": "~0.6.0",
-    "underscore": "~1.6.0",
     "process": "~0.6.0",
-    "browserify-shim": "3.3.2"
+    "type-of": "~2.0.1",
+    "underscore": "~1.6.0"
   },
   "devDependencies": {
     "async": "0.2.10",
-    "browserify": "3.46.1",
     "chai": "1.9.0",
     "express": "3.4.8",
     "grunt": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
     "type-of": "~2.0.1",
     "loglevel": "~0.6.0",
     "underscore": "~1.6.0",
-    "process": "~0.6.0"
+    "process": "~0.6.0",
+    "browserify-shim": "3.3.2"
   },
   "devDependencies": {
     "async": "0.2.10",
     "browserify": "3.46.1",
-    "browserify-shim": "3.3.2",
     "chai": "1.9.0",
     "express": "3.4.8",
     "grunt": "0.4.2",


### PR DESCRIPTION
Referenced in #210 -  We need this to be able to bundle `fh-js-sdk` in other projects using browserify.