### PR TITLE
fix sync namespace to user lowercase name

### DIFF
--- a/fh-js-sdk.d.ts
+++ b/fh-js-sdk.d.ts
@@ -236,9 +236,9 @@ declare module FeedHenry {
     /**
      * Sync namespace
      * 
-     * @namespace Sync
+     * @namespace sync
      */
-    export namespace Sync {
+    export namespace sync {
 
         /**
          * Interface for the data provided in the NotifyCallback in the notify function.


### PR DESCRIPTION
When using FH.Sync like so the code compiles fine:

```ts
import { Sync } from 'fh-js-sdk'

Sync.doUpdate('todos', todoId, todoData, successCb, failureCb);
```

At runtime this will fail since the generated code is:

```js
fh.Sync.doUpdate
```

but we really need

```js
fh.sync.doUpdate
```