### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.19.0 - 2017-06-29
+
+* RHMAP-16063 fix Client apps with disabled connection tags still working and the cloud calls not fail
+* Fix sync namespace to user lowercase name
+* Add browserify-shim as a dependency
+* Move fh-js-sdk to use upstream sync client
+
+## 2.18.5 - 2017-05-08
+
+* Recreate mock_uuid cookie if blank string
+* RHMAP-15272 - fh-wfm-sync does not allow overwriting sync options per dataset
+* FH-2763 - Write JavaScript documentation (JSDoc) for the public API in fh-js-sdk
+
+## 2.18.4 - 2017-02-20
+
+* RHMAP-13542 - Cannot Submit Map Location Data in Android Apps Built Using Android Form Builder
+
+## 2.18.3 - 2017-02-16
+
+* RAINCATCH-570 - update to the new browser api
+
+## 2.18.2 - 2017-02-03
+
+* RHMAP-12426 - Bug when section break component is used more than 10 times in an form with pages
+
+## 2.18.1 - 2017-01-04
+
+* RHMAP-12719 - Add an exception handler around doCloudCall so any exceptions can call the failure callback
+* RHMAP-11544 - Forms - "Blank" Dropdown options pass the required validation
+* fhconfig.json with local:true and host will skip FH.init for local dev
+* RHMAP-7811 - Add declaration file for TypeScript
+
+## 2.17.5 - 2016-11-18
+
+* RHMAP-11349 Stop submitting value in hidden field
+
 ## 2.17.4 - 2016-11-09 - Niall Donnelly
 
 * Added getUID function to public $fh.sync API.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ git push origin master
 Our SDK is release on [npmjs](https://www.npmjs.com/package/fh-js-sdk). To do a release follow those steps:
 
 ### Prepare release
-* Update ```package.json```, ```npm-shrinkwrap.json```, ``` ``` file with the new version number.
+* Update ```package.json```, ```npm-shrinkwrap.json```, ```bower.json``` file with the new version number.
 * Update ```CHANGELOG.md``` with some JIRA link
 * Do a PR, make sure Travis build passed. Merge.
 * Tag the repository with the new version number:
@@ -184,7 +184,7 @@ npm publish
 ```
 
 ### Generate API doc
-The documentation is generated from `fh-js-sdk.d.ts`. 
+The documentation is generated from `fh-js-sdk.d.ts`.
 The generated doc is comitted in `doc/` folder and deployed to `gh-pages` so that feedhenry.org and portal documentation can pick it up from a published location.
 
 To publish doc, run the command:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.19.1",
+  "version": "2.19.0",
   "homepage": "https://github.com/feedhenry/fh-js-sdk",
   "authors": [
     "npm@feedhenry.com"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.19.1-rc1",
+  "version": "2.19.0",
   "dependencies": {
     "fh-sync-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.19.1",
+  "version": "2.19.0",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",


### PR DESCRIPTION
I've updated the changelog because it was out of date

I would like to release 2.19.1 to get RHMAP-16063 fix, but I noticed that 2.19.0 has not been released. 
Should I downgrade the version to 2.19.0 and do a 2.19.0 release instead?

@wei-lee @wtrocki 