### PR TITLE
Prune empty values in repeating sections

### DIFF
--- a/src/appforms/src/backbone/040-view02field01field.js
+++ b/src/appforms/src/backbone/040-view02field01field.js
@@ -173,7 +173,7 @@ var FieldView = Backbone.View.extend({
         var submission = this.options.formView.getSubmission();
         if (submission) {
             this.submission = submission;
-            this.submission.getInputValueByFieldId(this.model.get('_id'), function(err, res) {
+            this.submission.getInputValueByFieldId(this.model.get('_id'), this.options.sectionIndex, function(err, res) {
                 self.value(res);
             });
         }

--- a/src/appforms/src/backbone/040-view02section.js
+++ b/src/appforms/src/backbone/040-view02section.js
@@ -1,7 +1,7 @@
 var SectionView=Backbone.View.extend({
 
-  addInputButtonClass: ".fh_appform_addSectionBtn",
-  removeInputButtonClass: ".fh_appform_removeSectionBtn",
+  addSectionButtonClass: ".fh_appform_addSectionBtn",
+  removeSectionButtonClass: ".fh_appform_removeSectionBtn",
 
   viewMap: {
     "text": FieldTextView,
@@ -30,15 +30,15 @@ var SectionView=Backbone.View.extend({
     var secMaxRepeat = this.secMaxRepeat;
     var minRepeat = this.secInitialRepeat;
     if (curNum < secMaxRepeat) {
-      this.$sec_fh_appform_fieldActionBar.find(this.addInputButtonClass).show();
+      this.$sec_fh_appform_fieldActionBar.find(this.addSectionButtonClass).show();
     } else {
-      this.$sec_fh_appform_fieldActionBar.find(this.addInputButtonClass).hide();
+      this.$sec_fh_appform_fieldActionBar.find(this.addSectionButtonClass).hide();
     }
 
     if (curNum > minRepeat) {
-      this.$sec_fh_appform_fieldActionBar.find(this.removeInputButtonClass).show();
+      this.$sec_fh_appform_fieldActionBar.find(this.removeSectionButtonClass).show();
     } else {
-      this.$sec_fh_appform_fieldActionBar.find(this.removeInputButtonClass).hide();
+      this.$sec_fh_appform_fieldActionBar.find(this.removeSectionButtonClass).hide();
     }
   },
 
@@ -49,27 +49,8 @@ var SectionView=Backbone.View.extend({
     this.renderSection(index);
 
     this.secCurRepeat++;
-  },
 
-  showSection: function() {
-    var self = this;
-    var secCurRepeat = this.secCurRepeat;
-    var nextIndex = secCurRepeat;
-    var sectionWrapper = $(self.sectionWrapper[0]);
-    var nextSection = sectionWrapper.find('#fh_appform_' + self.options.sectionKey + '_' + nextIndex);
-    nextSection.show();
-    this.secCurRepeat++;
-
-  },
-
-  hideSection: function() {
-    var self = this;
-    var secCurRepeat = this.secCurRepeat;
-    var lastIndex = secCurRepeat - 1;
-    var sectionWrapper = $(self.sectionWrapper[0]);
-    var lastSection = sectionWrapper.find('#fh_appform_' + self.options.sectionKey + '_' + lastIndex);
-    lastSection.hide();
-    this.secCurRepeat--;
+    this.options.formView.getFieldViews();
   },
 
   removeSection: function() {
@@ -79,7 +60,20 @@ var SectionView=Backbone.View.extend({
     var sectionWrapper = $(self.sectionWrapper[0]);
     var lastSection = sectionWrapper.find('#fh_appform_' + self.options.sectionKey + '_' + lastIndex);
     lastSection.remove();
+
+    self.options.fields.forEach(function(field){
+      var fieldType = field.getType();
+      if (self.viewMap[fieldType]) {
+        if(fieldType !== "sectionBreak"){
+          self.options.formView.submission.removeFieldValue(field.get('_id'), null, lastIndex);
+          self.options.formView.submission.removeFormField(field.get('_id'), lastIndex);
+          delete self.options.parentView.fieldViews[field.get('_id') + '_' + lastIndex];
+        }
+      }
+    });
+
     this.secCurRepeat--;
+    this.options.formView.getFieldViews();
   },
 
   initialize: function(options) {
@@ -172,22 +166,19 @@ var SectionView=Backbone.View.extend({
     this.options.parentEl.append(this.sectionWrapper);
 
 
-    for (var i = 0; i < this.secMaxRepeat; i++) {
+    for (var i = 0; i < this.secInitialRepeat; i++) {
       this.addSection();
-    }
-    for (i = this.secInitialRepeat; i < this.secMaxRepeat; i++) {
-      this.hideSection();
     }
 
     this.$sec_fh_appform_fieldActionBar = $(this.sectionWrapper[0]).find('.fh_appform_section_button_bar');
 
-    this.$sec_fh_appform_fieldActionBar.find('.fh_appform_addSectionBtn').unbind().bind('click', function() {
-      self.showSection();
+    this.$sec_fh_appform_fieldActionBar.find(this.addSectionButtonClass).unbind().bind('click', function() {
+      self.addSection();
       self.checkActionBar();
     });
 
-    this.$sec_fh_appform_fieldActionBar.find('.fh_appform_removeSectionBtn').unbind().bind('click', function() {
-      self.hideSection();
+    this.$sec_fh_appform_fieldActionBar.find(this.removeSectionButtonClass).unbind().bind('click', function() {
+      self.removeSection();
       self.checkActionBar();
     });
 

--- a/src/appforms/src/backbone/040-view04Form.js
+++ b/src/appforms/src/backbone/040-view04Form.js
@@ -165,25 +165,31 @@ var FormView = BaseView.extend({
       });
       pageViews.push(pageView);
     }
+    
+    self.pageViews = pageViews;
+    self.pageCount = pageViews.length;
+
+    this.getFieldViews();
+
+    var buttonsHtml = _.template(self.$el.find('#temp_form_buttons').html())();
+    this.$el.find("#fh_appform_container.fh_appform_form_area").append(buttonsHtml);
+  },
+  getFieldViews: function() {
     var fieldViews = [];
-    for (i = 0; i < pageViews.length; i++) {
-      pageView = pageViews[i];
+    for (i = 0; i < this.pageViews.length; i++) {
+      pageView = this.pageViews[i];
       var pageFieldViews = pageView.fieldViews;
       for (var key in pageFieldViews) {
         var fView = pageFieldViews[key];
         fieldViews.push(fView);
-        fView.on("checkrules", self.checkRules);
-        if (self.readonly) {
+        fView.on("checkrules", this.checkRules);
+        if (this.readonly) {
           fView.$el.find("input,button,textarea,select").attr("disabled", "disabled");
         }
       }
     }
 
-    self.fieldViews = fieldViews;
-    self.pageViews = pageViews;
-    self.pageCount = pageViews.length;
-    var buttonsHtml = _.template(self.$el.find('#temp_form_buttons').html())();
-    this.$el.find("#fh_appform_container.fh_appform_form_area").append(buttonsHtml);
+    this.fieldViews = fieldViews;
   },
   checkRules: function(params) {
     var self = this;
@@ -506,7 +512,7 @@ var FormView = BaseView.extend({
     this.submission.addInputValue(params, cb);
   },
   removeFieldInputValue: function(params) {
-    this.submission.removeFieldValue(params.fieldId, params.index);
+    this.submission.removeFieldValue(params.fieldId, params.index, params.sectionIndex);
   },
   populateFieldViewsToSubmission: function(isStore, cb) {
     if (typeof cb === "undefined") {

--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -988,6 +988,23 @@ appForm.models = function(module) {
   };
 
   /**
+   * Remove form field completaly from submission - needed for repeating sections.
+   */
+  Submission.prototype.removeFormField = function(fieldId, sectionIndex) {
+    // remove it completely from submission - needed for repeating sections
+    if (this.transactionMode) {
+      delete this.tmpFields[fieldId + ':' + sectionIndex];
+    } else {
+      var formField = this.getInputValueObjectById(fieldId, sectionIndex);
+      var formFields = this.getFormFields();
+      var index = formFields.indexOf(formField);
+      if (index > -1) {
+        formFields.splice(index, 1);
+      }
+    }
+  };
+
+  /**
    * Returns object representing the field along with its values.
    * @param {string} fieldId - id of the field
    * @param {number} sectionIndex - optional section id in case field is in repeating section


### PR DESCRIPTION
# Motivation
https://issues.jboss.org/browse/RHMAP-17078

# Changes
- all repeating sections are not generated initially, rather they are being generated as needed
- small fixes - pass `sectionIndex` as parameter

# Verification steps
1. have a form with repeating section
2. try to submit form with only one section
3. submission should contain only values from the first section