### PR TITLE
Add a getSectionValues API to the Submission model

### DIFF
--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -255,8 +255,6 @@ appForm.models = function(module) {
 
         var ruleTypes = ["fields", "pages"];
 
-        var sectionMap = getSectionMap(formModel);
-
         //For page and field rule actions, find the hidden fields.
         var allHiddenFieldIds = _.map(ruleTypes, function(ruleType) {
           var fieldIds = [];
@@ -1089,6 +1087,29 @@ appForm.models = function(module) {
 
     formFields.push(newField);
     return newField;
+  };
+
+  /**
+   * Returns submission values for fields in section identified with id and index.
+   * @param {string} sectionId
+   * @param {number} sectionIndex
+   * @returns {[object]}
+   */
+  Submission.prototype.getSectionValues = function(sectionId, sectionIndex, cb) {
+    var self = this;
+    if (_.isUndefined(sectionIndex)) {
+      sectionIndex = 0;
+    }
+    var formFields = this.getFormFields();
+    this.getForm(function(err, formModel) {
+      var sectionMap = getSectionMap(formModel);
+      var sectionFields = formFields.filter(function(field) {
+        var sectionOk = sectionMap[field.fieldId] && sectionMap[field.fieldId].props._id === sectionId;
+        return sectionOk && field.sectionIndex === sectionIndex;
+      });
+
+      cb(null, sectionFields);
+    });
   };
 
   /**


### PR DESCRIPTION
# Motivation
https://issues.jboss.org/browse/RHMAP-9426

# Verification steps
- in `040-Model06Submission.js` after line 247 add this code:
```
var repSec;
for (var key in formModel.fields) {
  var field = formModel.fields[key];
  if (field.props.type === 'sectionBreak' && field.props.repeating) {
    repSec = field;
  }
}

self.getSectionValues(repSec.props._id, 0, function(err, v) {
  console.log('TEST', v);
});
```
- submit form and check console, there should be list of values for first repeating section