### PR TITLE
Version bump fh-sync-js

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -305,9 +305,9 @@
       "resolved": "https://registry.npmjs.org/exposify/-/exposify-0.1.5.tgz"
     },
     "fh-sync-js": {
-      "version": "1.0.3",
-      "from": "fh-sync-js@1.0.3",
-      "resolved": "https://registry.npmjs.org/fh-sync-js/-/fh-sync-js-1.0.3.tgz",
+      "version": "1.1.1",
+      "from": "fh-sync-js@1.1.1",
+      "resolved": "https://registry.npmjs.org/fh-sync-js/-/fh-sync-js-1.1.1.tgz",
       "dependencies": {
         "uuid": {
           "version": "3.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "dependencies": {
     "acorn": {
       "version": "4.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.22.0",
+  "version": "2.22.1",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "license": "Copyright (c) 2014 FeedHenry Ltd, All Rights Reserved.",
   "gitHead": "251a1f88a39f59f2652552ae245893a833faee71",
   "dependencies": {
-    "fh-sync-js": "1.0.3",
+    "fh-sync-js": "1.1.1",
     "browserify": "3.46.1",
     "browserify-shim": "~3.3.2",
     "loglevel": "~0.6.0",


### PR DESCRIPTION
## Motivation 

Update version of the sync client. 
It looks like version weren't updated for a while.

Related sync change: 
https://github.com/feedhenry/fh-sync-js/pull/31

## Testing

I'm going to run set of standard tests on this version to make sure that we do not have any regression issues. 

### Verification steps

#### Acceptance tests

1) Use sync acceptance testing project:
https://github.com/feedhenry/sync-acceptance-testing

2) npm link this version fh-js-sdk 

3) Run tests

#### Platform testing

1) Run sync on the cloud (nothing required)

2) Use tutorial application to test cloud app.
https://github.com/feedhenry-templates/sync-tutorial-app/
 