### PR TITLE
Rhmap 16295 studio xss fixes

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "dependencies": {
     "acorn": {
       "version": "4.0.13",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "grunt-coveralls": "^1.0.1",
     "grunt-env": "0.4.1",
     "grunt-jscoverage": "^0.1.3",
-    "grunt-mocha-phantomjs": "0.4.3",
+    "grunt-mocha-phantomjs": "0.7.0",
     "grunt-mocha-test": "0.9.4",
     "grunt-shell": "0.6.4",
     "grunt-text-replace": "0.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.22.1",
+  "version": "2.22.2",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",

--- a/src/appforms/src/core/060-RuleEngine.js
+++ b/src/appforms/src/core/060-RuleEngine.js
@@ -1306,6 +1306,10 @@
 
         //Finding the selected option
         var found = _.find(fieldDefinition.fieldOptions.definition.options, function(dropdownOption) {
+          //fieldValue needs to be escaped here in order to match the label (label is already escaped)
+          fieldValue = _.escape(fieldValue);
+          // label needs to be escaped again here because the '&' character is not escaped
+          dropdownOption.label = _.escape(dropdownOption.label);
           return dropdownOption.label === fieldValue;
         });
 
@@ -1343,6 +1347,8 @@
         }
 
         async.some(fieldDefinition.fieldOptions.definition.options, function(dropdownOption, cb) {
+          //fieldValue needs to be escaped here in order to match the label (label is already escaped)
+          fieldValue = _.escape(fieldValue);
           return cb(dropdownOption.label === fieldValue);
         }, function(found) {
           if (!found) {
@@ -1395,6 +1401,8 @@
               return cb(new Error("Expected checkbox submission to be string but got " + typeof(selection)));
             }
 
+            //selection needs to be escaped here
+            selection = _.escape(selection);
             if (optionsInCheckbox.indexOf(selection) === -1) {
               return cb(new Error("Checkbox Option " + selection + " does not exist in the field."));
             }


### PR DESCRIPTION
## Motivation
The form input is validated in the app preview and due to the changes in this ticket [RHMAP-9354](https://issues.jboss.org/browse/RHMAP-9354) (where special characters in a form label get escaped) the form label does not match the form field value and therefore throws a validation error because they don't match.

## Result
Escape the form field value too

## Jira
https://issues.jboss.org/browse/RHMAP-16297