### PR TITLE
RHMAP-18146 - Stop overflowing call stack when doing large synchronous iterations 

### DIFF
--- a/src/appforms/src/core/040-Model06Submission.js
+++ b/src/appforms/src/core/040-Model06Submission.js
@@ -980,7 +980,11 @@ appForm.models = function(module) {
           return cb(null, valRemoved);
         });
       } else {
-        return cb();
+        //defer to stop calling callbacks iteratively as this will quickly overflow the stack
+        // More info: https://github.com/caolan/async/blob/master/intro.md#synchronous-iteration-functions
+          async.setImmediate(function() {
+            return cb();
+          });
       }
     }, function(err){
       callback(err);


### PR DESCRIPTION
## Motivation
When iterating a large number of fields in a form to remove hidden fields it results in an overflow of the call stack due to a synchronous if block where we don't clean up localstorage. 

https://github.com/feedhenry/fh-js-sdk/blob/146b72715cb1625eb9f472ca3f9f7cf9b5016f3d/src/appforms/src/core/040-Model06Submission.js#L983

This is happening due to a removed guard in async versions 2+. More details and reading here: https://github.com/caolan/async/blob/master/intro.md#synchronous-iteration-functions

## Result
Defer callback inside a synchronous block using async.setImmediate. (See https://github.com/caolan/async/blob/master/intro.md#synchronous-iteration-functions) 

## Jira
https://issues.jboss.org/browse/RHMAP-18146