### PR TITLE
FIX: RHMAP-19268 - Client gets null pointer exception when connection tag is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 2.24.1 - 2018-02-01
+* FIX: RHMAP-19268 - Client gets null pointer exception when connection tag is disabled and the app is running localy
+
 ## 2.24.0 - 2018-01-25
 * Added `headers` parameter to CloudOptions
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.19.0",
+  "version": "2.24.1",
   "homepage": "https://github.com/feedhenry/fh-js-sdk",
   "authors": [
     "npm@feedhenry.com"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "dependencies": {
     "browserify": {
       "version": "3.46.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "2.24.0",
+  "version": "2.24.1",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",

--- a/src/modules/initializer.js
+++ b/src/modules/initializer.js
@@ -83,7 +83,7 @@ var loadCloudProps = function(app_props, callback) {
         }
         logger.error("App init returned error : " + errormsg);
         //use the cached host if we have a copy
-        if (savedHost && req.status !== 400) {
+        if (savedHost && (!req || req.status !== 400)) {
           logger.info("Using cached host: " + JSON.stringify(savedHost));
           if (callback) {
             callback(null, {
@@ -91,7 +91,7 @@ var loadCloudProps = function(app_props, callback) {
             });
           }
         } else {
-          if (req.status === 400) {
+          if (req && req.status === 400) {
             logger.error(req.responseText);
           } else {
             logger.error("No cached host found. Init failed.");


### PR DESCRIPTION
Ref the Issue: https://github.com/feedhenry/fh-js-sdk/issues/256
JIRA: https://issues.jboss.org/browse/RHMAP-19268  

**Root cause:** The validation/implementation `req.status` was added without considering that the `req` can be `undefined` in some situation. In order to prove it note that the `req` is checked at another point implemented previously. ( https://github.com/feedhenry/fh-js-sdk/blob/2.23.0/src/modules/initializer.js#L81 )
