### PR TITLE
Add missing callback parameter

### DIFF
--- a/fh-js-sdk.d.ts
+++ b/fh-js-sdk.d.ts
@@ -490,7 +490,7 @@ declare module FeedHenry {
          * @param {String} datasetId
          * @param {Function} callback
          */
-        function getPending(datasetId: string, callback: () => void);
+        function getPending(datasetId: string, callback: (pending: any) => void);
 
         /**
          * @param {String} datasetId


### PR DESCRIPTION
The `getPending` definition is missing the the parameter in the callback function.