### PR TITLE
Add queryParams to setQueryParams definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 3.0.2 - 2018-04-30
+* Add missing argument to `sync.setQueryParams` definition
+
 ## 3.0.1 - 2018-04-26
 * Add missing callback parameter in `sync.getPending`
 

--- a/fh-js-sdk.d.ts
+++ b/fh-js-sdk.d.ts
@@ -156,7 +156,7 @@ declare module FeedHenry {
 
       /**
        * Delete the locally stored session token. Will also request that the RHMAP server revoke it
-       * @param callback 
+       * @param callback
        */
       export function clearSession(callback: (err: any) => void)
     }
@@ -514,10 +514,11 @@ declare module FeedHenry {
 
         /**
          * @param {String} datasetId
+         * @param {Object} queryParams
          * @param {Function} success
          * @param {Function} failure
          */
-        function setQueryParams(datasetId: string, success: (queryParams: any) => void, failure: (err: string, datasetId: string) => void);
+        function setQueryParams(datasetId: string, queryParams: any, success?: (queryParams: any) => void, failure?: (err: string, datasetId: string) => void);
 
         /**
          * @param {String} datasetId

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",


### PR DESCRIPTION
# What
Correct the type definition for the `sync.setQueryParams` function.

# Why
The current definition for `sync.setQueryParams` is incorrect and causes errors when using this function within a TypeScript application.

# How
Changing the `fh-js-sdk.d.ts` file to match the `setQueryParams` function found [here](https://github.com/feedhenry/fh-sync-js/blob/master/src/sync-client.js#L407).

# Verification Steps
- Open the source code for the `setQueryParams` function [here](https://github.com/feedhenry/fh-sync-js/blob/master/src/sync-client.js#L407).
- Verify the new definition matches the function signature in the `fh-sync-js` repo.