### PR TITLE
[fix] - FH-4887 - fh-js-sdk - Fix grunt test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - '0.10'
+  - '6.0.0'
 before_install:
-  - npm install -g npm@2.13.5
+  - npm install -g npm@3.8.6
   - npm install -g grunt-cli
 install: npm install
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 3.0.1 - 2018-04-24
+* FIX: Unable to run `grunt test` locally
+
 ## 3.0.0 - 2018-02-01
 * Remove titanium option as per ticket FH-3250 we are no longer supporting Titanium/appcelerator apps.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "dependencies": {
     "browserify": {
       "version": "3.46.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "grunt-coveralls": "^1.0.1",
     "grunt-env": "0.4.1",
     "grunt-jscoverage": "^0.1.3",
-    "grunt-mocha-phantomjs": "0.7.0",
+    "grunt-mocha-phantomjs": "2.0.1",
     "grunt-mocha-test": "0.9.4",
     "grunt-shell": "0.6.4",
     "grunt-text-replace": "0.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",


### PR DESCRIPTION
# Jira link
https://issues.jboss.org/browse/FH-4887

# What
Solve issue to run grunt test task locally

# Why
Unable to run the `grunt test` command
 
# How
By update the version of grunt-mocha-phantomjs from X to 2.0.1

# Test
Clone the project and check if is possible run the tests locally with success (`grunt test`)

~~~
cmacedo@camilas-MBP ~/fh-sdks/fh-js-sdk (FH-4887) $ grunt test
Running "jshint:all" (jshint) task
>> 113 files lint free.

Running "browserify:dist" (browserify) task
found current version = 3.0.0
Version to inject is 3.0.0
>> Bundled dist/feedhenry.js

Running "browserify:require" (browserify) task
>> Bundled test/browser/feedhenry-latest-require.js

Running "browserify:test" (browserify) task
>> Bundled ./test/browser/browserified_tests.js

Running "connect:server" (connect) task
Started connect web server on http://:::8200

Running "mocha_phantomjs:test" (mocha_phantomjs) task

Done, without errors.
cmacedo@camilas-MBP ~/fh-sdks/fh-js-sdk (FH-4887) $ 
~~~
