### PR TITLE
[task] - FH-4890: Update NodeJS version on travis to 6.11.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: node_js
 sudo: false
 node_js:
-  - '0.10'
+  - '4'
+  - '6'
+  - '8'
 before_install:
-  - npm install -g npm@2.13.5
   - npm install -g grunt-cli
 install: npm install
 script:


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20276

## WHAT
Update NodeJS version to use 4, 6, and 8 as follows.

```
node_js:
  - '4'
  - '6'
  - '8'
```

## WHY
The current version adopted for RHMAP is 6.11.3 and the version 0.10 used here is deprecated.  

## Verification Steps:
Check if the all steps in Trevis are finishing with success. 
