### PR TITLE
[task] - Remove the fix npm used to run the tests in the CI/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - '6'
   - '8'
 before_install:
-  - npm install -g npm@3.10.8
   - npm install -g grunt-cli
 install: npm install
 script:


### PR DESCRIPTION
## WHAT:

Remove the fix npm used to run the tests in the CI/Travis

## WHY:

It was checked that for each version is used one version and in this way, the test should be made with the default npm for each NodeJS version. 