### PR TITLE
task(CVE-2017-18214): RHMAP-20720 - Remove moment dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog - FeedHenry Javascript SDK
 
-## Unreleased - Wed May 14, 2018
-### Change
+## 3.0.5 - 2018-06-12
 - Add scripts to update the licenses automatically
 - Update automatically lock dependencies file (npm-shrinkwrap.json) and licenses
+- CVE-2017-18214 : Remove unused moment dependency
 
 ## 3.0.4 - 2018-05-10
 * Upgrade dependencies which do not have break changes  

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "dependencies": {
     "browserify": {
       "version": "16.2.2",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "json2lcov": "^1.0.0",
     "license-reporter": "github:bucharest-gold/license-reporter#d74abaf47220137b6dfd3a070556c6d5c4f2003b",
     "mocha": "5.1.1",
-    "moment": "^2.18.1",
     "phantomjs": "1.9.7-15",
     "rimraf": "2.6.2",
     "sinon": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",


### PR DESCRIPTION
## JIRA
https://issues.jboss.org/browse/RHMAP-20720

## WHAT
- Remove moment dependency from dev dependencies because it is not used.

## WHY
* Solve vulnerability. For further information check: https://nvd.nist.gov/vuln/detail/CVE-2017-18214
* Dep not used

## USAGE
No usage, it was declared in the dev deps. 

## STEPS TO TEST
* Run `grunt` tasks and/or check if the CI/Travis in PR was succeeded

