### PR TITLE
fix(Some FH request headers are not formatted correctly): RHMAP-19117

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 3.0.6 - 2018-07-20
+- Fix header parameters  
+
 ## 3.0.5 - 2018-06-12
 - Add scripts to update the licenses automatically
 - Update automatically lock dependencies file (npm-shrinkwrap.json) and licenses

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "dependencies": {
     "browserify": {
       "version": "16.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",

--- a/src/modules/fhparams.js
+++ b/src/modules/fhparams.js
@@ -14,7 +14,7 @@ var buildFHParams = function(){
   fhparams.cuid = device.getDeviceId();
   fhparams.cuidMap = device.getCuidMap();
   fhparams.destination = device.getDestination();
-  
+
   if(window.device || navigator.device){
     fhparams.device = window.device || navigator.device;
   }
@@ -45,7 +45,7 @@ var buildFHParams = function(){
       fhparams.init = typeof(app_props.init) === "string" ? JSON.parse(app_props.init) : app_props.init;
     }
   }
-  
+
   defaultParams = fhparams;
   logger.debug("fhparams = ", defaultParams);
   return fhparams;
@@ -63,7 +63,7 @@ var getFHHeaders = function(){
   var params = buildFHParams();
   for(var name in params){
     if(params.hasOwnProperty(name)){
-      headers['X-FH-' + name] = params[name];
+      headers['X-FH-' + name] = JSON.stringify(params[name]);
     }
   }
   return headers;


### PR DESCRIPTION
# JIRA:
https://issues.jboss.org/browse/RHMAP-19117

# WHAT:
Some FH request headers are not formatted correctly. Following an example. 
```javascript
X-FH-init:[object Object]
```

# WHY:
Because the code which creates ALL params of the header is not expecting an object. 
```javascript
headers['X-FH-' + name] = params[name];
```

# HOW:
By transforming objects in JSON 
```javascript
 headers['X-FH-' + name] = JSON.stringify(params[name]);
```

# STEPS TO VERIFY: 
* Clone this PR
* Run `npm install` and `grunt`
* Create a Cordova Hello World project and update the main.js file of the client application with this content. 
* Follow the steps described in the JIRA to reproduce the issue. 
* The header values should not so long be as [Object Object] 

Following local test. 

<img width="1235" alt="screen shot 2018-07-20 at 22 28 16" src="https://user-images.githubusercontent.com/7708031/43031854-47bf7542-8ca2-11e8-9d49-a725f853420b.png">




