### PR TITLE
Default fhconfig path should include forward slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 3.0.7 - 2018-08-04
+- Set fhconfig.json default to /fhconfig.json
+
 ## 3.0.6 - 2018-07-20
-- Fix header parameters  
+- Fix header parameters
 
 ## 3.0.5 - 2018-06-12
 - Add scripts to update the licenses automatically
@@ -9,7 +12,7 @@
 - CVE-2017-18214 : Remove unused moment dependency
 
 ## 3.0.4 - 2018-05-10
-* Upgrade dependencies which do not have break changes  
+* Upgrade dependencies which do not have break changes
 * Update licenses manually
 
 ## 3.0.3 - 2018-05-09

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",

--- a/src/modules/constants.js
+++ b/src/modules/constants.js
@@ -1,7 +1,7 @@
 module.exports = {
   "boxprefix": "/box/srv/1.1/",
   "sdk_version": "BUILD_VERSION",
-  "config_js": "fhconfig.json",
+  "config_js": "/fhconfig.json",
   "INIT_EVENT": "fhinit",
   "INTERNAL_CONFIG_LOADED_EVENT": "internalfhconfigloaded",
   "CONFIG_LOADED_EVENT": "fhconfigloaded",


### PR DESCRIPTION
# What

The `config_js` const should include a forward slash to allow requesting the config file even if the user is not on the main page of a site.

# Why

Currently if I visit `www.companysite.com/list/1/overview` and I refresh the page then when the `fh-js-sdk` library loads the `fhconfig.json` file will be requested from `www.companysite.com/list/1/fhconfig.json`. It should be requested from `www.companysite.com/fhconfig.json` which this change will enable.


# How

Adding a simple forward slash to the beginning of the `config_js` const.



# Verification Steps
Load the package in a site with several items in the path `/list/1/overview` and ensure `fhconfig.json` is still requested from `/fhconfig.json` and not `/list/1/fhconfig.json`

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
