### PR TITLE
RHMAP-19715 - Fix date form component which is not working when the button is used 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 3.0.7 - 2018-08-21
+- Fix date form component which is not working when the button is used 
+
 ## 3.0.6 - 2018-07-20
 - Fix header parameters  
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "dependencies": {
     "browserify": {
       "version": "16.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",

--- a/src/appforms/src/backbone/040-view02field27dateTime.js
+++ b/src/appforms/src/backbone/040-view02field27dateTime.js
@@ -30,9 +30,9 @@ FieldDateTimeView = FieldView.extend({
     });
 
     if(!this.readonly){
-      html+=this.renderButton(index,buttonLabel,"fhdate");   
+      html+=this.renderButton(index,buttonLabel,"fhdate");
     }
-    
+
 
     return $(html);
   },
@@ -49,7 +49,7 @@ FieldDateTimeView = FieldView.extend({
     if(!this.readonly){
       this.$el.on("click","button",function(){
         that.action(this);
-      });  
+      });
     }
   },
   action: function(el) {
@@ -57,11 +57,11 @@ FieldDateTimeView = FieldView.extend({
     var self = this;
     var now=new Date();
     if (self.getUnit() === "datetime") {
-      $('input[data-index="'+index+'"]', this.$el).val(self.generateDateTimeText(now)).blur();
+      $('input[data-index="'+index+'"]', this.$el).val(self.generateDateTimeText(now)).change();
     } else if (self.getUnit() === "date") {
-      $('input[data-index="'+index+'"]', this.$el).val(self.getDate(now)).blur();
+      $('input[data-index="'+index+'"]', this.$el).val(self.getDate(now)).change();
     } else if (self.getUnit() === "time") {
-      $('input[data-index="'+index+'"]', this.$el).val(self.getTime(now)).blur();
+      $('input[data-index="'+index+'"]', this.$el).val(self.getTime(now)).change();
     }
   },
   generateDateTimeText: function(date){


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-19715

# What
The rules set up for the form is not applied when the value is added by the button.  

# Why
When the date is set by the button the validate rules are not called and the rules configured for this form is not applied. 

When the value is added manually:
<img width="796" alt="screen shot 2018-08-16 at 00 51 24" src="https://user-images.githubusercontent.com/7708031/44384432-11b7fe80-a514-11e8-9335-ac7986bf17c5.png">

When the value is added via the button it is like empty:
<img width="712" alt="screen shot 2018-08-16 at 00 51 04" src="https://user-images.githubusercontent.com/7708031/44384433-12509500-a514-11e8-9af1-02c0ed4774cd.png">

# How
Change the event used when the button is called. 

# Verification Steps
- Go to the studio
- Create a new form project
- Create a new form as follows. 
** With: date component, and an input A, and an input B

<img width="519" alt="screen shot 2018-08-21 at 07 44 20" src="https://user-images.githubusercontent.com/7708031/44385002-09f95980-a516-11e8-9df4-eb1c8ee2c071.png">

** Create a rule to show the input A just if the date is upper than `2017-01-01 00:00:00`

<img width="609" alt="screen shot 2018-08-21 at 07 43 45" src="https://user-images.githubusercontent.com/7708031/44384980-fa7a1080-a515-11e8-8e54-2f2b7242d68a.png">

- Deploy the form
- Associated the form the form project created
- Deploy the cloud app for this project
- Update the `www/lib.min.js` with the content of this SDK
- Open the preview and check if the input A will appears when clicking on in the button.  

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
