### PR TITLE
Add message when has error to initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - FeedHenry Javascript SDK
 
+## 3.0.12 - 2018-11-30
+### Fix
+- Add default result for init requests across domains when the result is not successful which is expected when the connection tag is disable.
+
 ## 3.0.11 - 2018-08-29
 ### Fix
 - Unable to build client app regards issue introduce in the changes made in the version 3.0.3.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-js-sdk",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "feedhenry js sdk",
   "main": "dist/feedhenry.js",
   "types": "./fh-js-sdk.d.ts",

--- a/src/modules/initializer.js
+++ b/src/modules/initializer.js
@@ -94,6 +94,10 @@ var loadCloudProps = function(app_props, callback) {
           if (req && req.status === 400) {
             logger.error(req.responseText);
           } else {
+            if ( !req && !statusText && !error ) {
+              statusText = "Connection tag may be disabled";
+              error = "No cached host found. Init failed.";
+            }
             logger.error("No cached host found. Init failed.");
           }
           handleError(function(msg, err) {


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-22002

# What
Add default result for init requests across domains when the result is not successful which is expected when the connection tag is disable.


# Why
In this situation all values are returned as undefined which has been a complain by its users.

# How
If all be undefined then return a descriptive and default message. 

# Verification Steps
1. Create a WebApp project
2. Clone locally this PR and run ( npm install and grunt )
3. Update the main.js file in the client web app in the platform with the "dist/feedhenry.js" generated locally.
4. Disable the connection tab 
5. Copy the index.html and hello.js to the public dir of the web client app
6. Update the index.html to looking for hello.js in the public dir
7. Deploy it
8. Test it by the preview. The following result is the expected one when the button is clicked. 

<img width="485" alt="screenshot 2018-11-30 at 11 19 24" src="https://user-images.githubusercontent.com/7708031/49295082-c024f580-f4ac-11e8-9201-608d30452be8.png">

NOTE: It can be tested here: https://support.eu.feedhenry.com/?#projects/qi6v7wo4psfilh6y7furo6hm/apps/qi6v7wnhylp2y7u4m3r4i67v/deploy

The dev tag created to test it is: 3.0.12-dev-1 

## Checklist:

- [X] Code has been tested locally by PR requester (Full tested with WebApp as described in the steps, and with Cordova and with Ionic template + webviews. See [here](https://support.eu.feedhenry.com/?#projects/4542qwatf37iwzifuymdwx7t/apps/4542qwfewzstqfdg67gv6i3a/details))

![img_e5a6cc0070fc-1](https://user-images.githubusercontent.com/7708031/49306659-c75afc00-f4ca-11e8-9dc3-2d36bdb941d6.jpeg)

- [ ] Changes have been successfully verified by another team member 

